### PR TITLE
feat(password-engine): service abstraction, animated generator UI

### DIFF
--- a/lib/core/design_system/components/common/app_icon_badge.dart
+++ b/lib/core/design_system/components/common/app_icon_badge.dart
@@ -11,7 +11,7 @@ import 'package:passvault/core/design_system/theme/theme.dart';
 /// ```dart
 /// AppIconBadge(
 ///   icon: LucideIcons.shield,
-///   color: Colors.green,
+///   color: context.theme.success,
 ///   size: AppIconBadgeSize.medium,
 /// )
 /// ```
@@ -42,7 +42,7 @@ class AppIconBadge extends StatelessWidget {
 
     return Semantics(
       image: true,
-      label: semanticLabel ?? 'Icon',
+      label: semanticLabel ?? context.l10n.optionIcon,
       child: DecoratedBox(
         decoration: BoxDecoration(
           color: color.withValues(alpha: 0.1),

--- a/lib/core/design_system/components/common/app_list_option.dart
+++ b/lib/core/design_system/components/common/app_list_option.dart
@@ -12,7 +12,7 @@ import 'package:passvault/core/design_system/theme/theme.dart';
 /// ```dart
 /// AppListOption(
 ///   icon: LucideIcons.fileText,
-///   iconColor: Colors.blue,
+///   iconColor: context.theme.primary,
 ///   title: 'Import from CSV',
 ///   subtitle: 'Import passwords from a CSV file',
 ///   onTap: () => _handleImport(),

--- a/lib/core/design_system/components/components.dart
+++ b/lib/core/design_system/components/components.dart
@@ -24,5 +24,6 @@ export 'feedback/app_shimmer_loading.dart';
 export 'inputs/app_text_field.dart';
 // Layout
 export 'layout/app_card.dart';
+export 'layout/app_feature_shell.dart';
 // Navigation
 export 'navigation/persistent_bottom_bar.dart';

--- a/lib/core/design_system/components/layout/app_feature_shell.dart
+++ b/lib/core/design_system/components/layout/app_feature_shell.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:passvault/core/design_system/components/common/page_header.dart';
+import 'package:passvault/core/design_system/theme/theme.dart';
+
+class AppFeatureShell extends StatelessWidget {
+  final String title;
+  final List<Widget> slivers;
+  final bool showBack;
+  final VoidCallback? onBack;
+  final Color? backgroundColor;
+  final Widget? floatingActionButton;
+  final Widget Function(BuildContext context, Widget child)? bodyWrapper;
+
+  const AppFeatureShell({
+    super.key,
+    required this.title,
+    required this.slivers,
+    this.showBack = false,
+    this.onBack,
+    this.backgroundColor,
+    this.floatingActionButton,
+    this.bodyWrapper,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final body = _buildBody(context);
+
+    return Scaffold(
+      backgroundColor: backgroundColor,
+      body: bodyWrapper?.call(context, body) ?? body,
+    );
+  }
+
+  Widget _buildBody(BuildContext context) {
+    final scrollView = CustomScrollView(
+      slivers: [
+        SliverToBoxAdapter(
+          child: SafeArea(
+            bottom: false,
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(
+                AppSpacing.l,
+                AppSpacing.m,
+                AppSpacing.l,
+                AppSpacing.s,
+              ),
+              child: PageHeader(
+                title: title,
+                showBack: showBack,
+                onBack: onBack,
+              ),
+            ),
+          ),
+        ),
+        ...slivers,
+      ],
+    );
+
+    if (floatingActionButton == null) {
+      return scrollView;
+    }
+
+    final bottomInset = MediaQuery.paddingOf(context).bottom;
+    const fabSize = 56.0;
+    final fabBottomOffset =
+        AppSpacing.m + (kBottomNavigationBarHeight - fabSize) / 2 + bottomInset;
+
+    return Stack(
+      children: [
+        scrollView,
+        Positioned(
+          right: AppSpacing.m,
+          bottom: fabBottomOffset,
+          child: SizedBox(
+            width: fabSize,
+            height: fabSize,
+            child: floatingActionButton!,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/core/design_system/theme/app_colors.dart
+++ b/lib/core/design_system/theme/app_colors.dart
@@ -7,6 +7,15 @@ import 'package:flutter/material.dart';
 /// Instead, access semantic colors via `context.theme` or `context.colors`
 /// provided by [AppThemeExtension].
 abstract class AppColors {
+  /// Opaque white token.
+  static const Color white = Color(0xFFFFFFFF);
+
+  /// Opaque black token.
+  static const Color black = Color(0xFF000000);
+
+  /// Fully transparent token.
+  static const Color transparent = Color(0x00000000);
+
   // Brand / Core
 
   /// Primary brand color for light theme (Blue).
@@ -36,7 +45,7 @@ abstract class AppColors {
   static const Color bgDark = Color(0xFF121212);
 
   /// Pure black background for AMOLED support (#000000).
-  static const Color bgAmoled = Colors.black;
+  static const Color bgAmoled = black;
 
   /// Default surface color (cards, sheets) for light theme.
   static const Color surfaceLight = Color(0xFFF5F5F5);

--- a/lib/core/design_system/theme/app_theme.dart
+++ b/lib/core/design_system/theme/app_theme.dart
@@ -78,10 +78,10 @@ class AppTheme {
         ? AppColors.textDarkSecondary
         : AppColors.textLightSecondary;
     final inputBorderColor = isAmoled
-        ? Colors.white24
+        ? AppColors.white.withValues(alpha: 0.24)
         : scheme.outline.withValues(alpha: isDark ? 0.62 : 0.58);
     final inputDisabledBorderColor = isAmoled
-        ? Colors.white24.withValues(alpha: 0.45)
+        ? AppColors.white.withValues(alpha: 0.11)
         : scheme.outline.withValues(alpha: isDark ? 0.40 : 0.36);
 
     final textTheme = const AppTextThemeBuilder(
@@ -96,11 +96,11 @@ class AppTheme {
       extensions: [extension],
       textTheme: textTheme,
       appBarTheme: AppBarTheme(
-        backgroundColor: Colors.transparent,
+        backgroundColor: AppColors.transparent,
         foregroundColor: textPrimary,
         elevation: 0,
         centerTitle: true,
-        surfaceTintColor: Colors.transparent,
+        surfaceTintColor: AppColors.transparent,
         systemOverlayStyle: isDark
             ? SystemUiOverlayStyle.light
             : SystemUiOverlayStyle.dark,
@@ -119,19 +119,19 @@ class AppTheme {
         color: surface,
         elevation: 0,
         margin: EdgeInsets.zero,
-        surfaceTintColor: Colors.transparent,
+        surfaceTintColor: AppColors.transparent,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(AppRadius.m),
           side: BorderSide(
             color: isAmoled
-                ? Colors.white.withValues(alpha: 0.1)
+                ? AppColors.white.withValues(alpha: 0.1)
                 : scheme.outline.withValues(alpha: 0.1),
           ),
         ),
       ),
       bottomSheetTheme: BottomSheetThemeData(
         backgroundColor: surface,
-        surfaceTintColor: Colors.transparent,
+        surfaceTintColor: AppColors.transparent,
         modalBackgroundColor: surface,
         shape: const RoundedRectangleBorder(
           borderRadius: BorderRadius.vertical(
@@ -207,7 +207,7 @@ class AppTheme {
         }),
         trackOutlineColor: WidgetStateProperty.resolveWith((states) {
           if (states.contains(WidgetState.selected)) {
-            return Colors.transparent;
+            return AppColors.transparent;
           }
           return scheme.outline;
         }),

--- a/lib/core/design_system/theme/presets/amoled_theme_preset.dart
+++ b/lib/core/design_system/theme/presets/amoled_theme_preset.dart
@@ -32,7 +32,7 @@ class AmoledThemePreset {
       primaryContainer: scheme.primaryContainer,
       onPrimaryContainer: scheme.onPrimaryContainer,
       cardShadow: BoxShadow(
-        color: Colors.white.withValues(alpha: 0.05),
+        color: AppColors.white.withValues(alpha: 0.05),
         blurRadius: 15,
         offset: const Offset(0, 0),
       ),
@@ -46,11 +46,11 @@ class AmoledThemePreset {
       ),
       bodyRelaxed: const TextStyle(height: 1.6, letterSpacing: 0.2),
       vaultGradient: const LinearGradient(
-        colors: [AppColors.vaultGradientDarkEnd, Colors.black],
+        colors: [AppColors.vaultGradientDarkEnd, AppColors.black],
         begin: Alignment.topLeft,
         end: Alignment.bottomRight,
       ),
-      onVaultGradient: Colors.white,
+      onVaultGradient: AppColors.white,
       inputFocusedBorder: AppColors.getPrimaryFocus(Brightness.dark),
       // AMOLED glow effects – subtle outer glow for accent elements on
       // pure-black backgrounds.  Blur 12, spread 1, accent at ~40% opacity.
@@ -91,8 +91,8 @@ class AmoledThemePreset {
     onSecondary: AppColors.bgAmoled,
     surface: AppColors.bgAmoled,
     onSurface: AppColors.textDarkPrimary,
-    surfaceDim: Colors.black,
-    surfaceContainerLowest: Colors.black,
+    surfaceDim: AppColors.black,
+    surfaceContainerLowest: AppColors.black,
     surfaceContainerLow: AppColors.amoledSurfaceContainerLow,
     surfaceContainer: AppColors.amoledSurfaceContainer,
     surfaceContainerHigh: AppColors.amoledSurfaceContainerHigh,

--- a/lib/core/design_system/theme/presets/dark_theme_preset.dart
+++ b/lib/core/design_system/theme/presets/dark_theme_preset.dart
@@ -32,7 +32,7 @@ class DarkThemePreset {
       primaryContainer: scheme.primaryContainer,
       onPrimaryContainer: scheme.onPrimaryContainer,
       cardShadow: BoxShadow(
-        color: Colors.black.withValues(alpha: 0.3),
+        color: AppColors.black.withValues(alpha: 0.3),
         blurRadius: 12,
         offset: const Offset(0, 4),
       ),
@@ -53,7 +53,7 @@ class DarkThemePreset {
         begin: Alignment.topLeft,
         end: Alignment.bottomRight,
       ),
-      onVaultGradient: Colors.white,
+      onVaultGradient: AppColors.white,
       inputFocusedBorder: AppColors.getPrimaryFocus(Brightness.dark),
     );
   }

--- a/lib/core/design_system/theme/presets/light_theme_preset.dart
+++ b/lib/core/design_system/theme/presets/light_theme_preset.dart
@@ -10,9 +10,9 @@ class LightThemePreset {
     final scheme = LightThemePreset.colorScheme;
     return AppThemeExtension(
       primary: AppColors.primaryLight,
-      onPrimary: Colors.white,
+      onPrimary: AppColors.white,
       secondary: AppColors.secondaryLight,
-      onSecondary: Colors.white,
+      onSecondary: AppColors.white,
       surface: AppColors.surfaceLight,
       onSurface: AppColors.textLightPrimary,
       background: AppColors.bgLight,
@@ -32,7 +32,7 @@ class LightThemePreset {
       primaryContainer: scheme.primaryContainer,
       onPrimaryContainer: scheme.onPrimaryContainer,
       cardShadow: BoxShadow(
-        color: Colors.black.withValues(alpha: 0.05),
+        color: AppColors.black.withValues(alpha: 0.05),
         blurRadius: 10,
         offset: const Offset(0, 4),
       ),
@@ -53,7 +53,7 @@ class LightThemePreset {
         begin: Alignment.topLeft,
         end: Alignment.bottomRight,
       ),
-      onVaultGradient: Colors.white,
+      onVaultGradient: AppColors.white,
       inputFocusedBorder: AppColors.getPrimaryFocus(Brightness.light),
     );
   }
@@ -62,9 +62,9 @@ class LightThemePreset {
     seedColor: AppColors.primaryLight,
     brightness: Brightness.light,
     primary: AppColors.primaryLight,
-    onPrimary: Colors.white,
+    onPrimary: AppColors.white,
     secondary: AppColors.secondaryLight,
-    onSecondary: Colors.white,
+    onSecondary: AppColors.white,
     surface: AppColors.surfaceLight,
     onSurface: AppColors.textLightPrimary,
     onSurfaceVariant: AppColors.textLightSecondary,

--- a/lib/features/generator/presentation/generator_screen.dart
+++ b/lib/features/generator/presentation/generator_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_animate/flutter_animate.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:passvault/core/design_system/components/components.dart';
@@ -8,73 +9,59 @@ import 'package:passvault/features/settings/presentation/bloc/settings/settings_
 
 import 'widgets/generator_sections.dart';
 
-class GeneratorScreen extends StatelessWidget {
+class GeneratorScreen extends StatefulWidget {
   const GeneratorScreen({super.key});
 
   @override
+  State<GeneratorScreen> createState() => _GeneratorScreenState();
+}
+
+class _GeneratorScreenState extends State<GeneratorScreen> {
+  int _refreshTick = 0;
+
+  void _handleGenerate() {
+    setState(() => _refreshTick++);
+    context.read<GeneratorBloc>().add(const GeneratorRequested());
+  }
+
+  @override
   Widget build(BuildContext context) {
-    final bottomInset = MediaQuery.paddingOf(context).bottom;
-    const fabSize = 56.0;
-    final fabBottomOffset =
-        AppSpacing.m + (kBottomNavigationBarHeight - fabSize) / 2 + bottomInset;
-    return Scaffold(
-      body: BlocListener<SettingsBloc, SettingsState>(
-        listenWhen: (previous, current) =>
-            previous.passwordSettings != current.passwordSettings,
-        listener: (context, state) {
-          context.read<GeneratorBloc>().add(const GeneratorStarted());
-        },
-        child: Stack(
-          children: [
-            CustomScrollView(
-              slivers: [
-                SliverToBoxAdapter(
-                  child: SafeArea(
-                    bottom: false,
-                    child: Padding(
-                      padding: const EdgeInsets.fromLTRB(
-                        AppSpacing.l,
-                        AppSpacing.m,
-                        AppSpacing.l,
-                        AppSpacing.s,
-                      ),
-                      child: PageHeader(title: context.l10n.passwordGenerator),
-                    ),
-                  ),
-                ),
-                BlocBuilder<GeneratorBloc, GeneratorState>(
-                  builder: (context, state) {
-                    return switch (state) {
-                      GeneratorLoading() => const SliverFillRemaining(
-                        child: Center(child: AppLoader()),
-                      ),
-                      GeneratorLoaded() => _GeneratorContentSliver(
-                        state: state,
-                      ),
-                    };
-                  },
-                ),
-              ],
-            ),
-            Positioned(
-              right: AppSpacing.m,
-              bottom: fabBottomOffset,
-              child: SizedBox(
-                width: fabSize,
-                height: fabSize,
-                child: FloatingActionButton(
-                  key: const Key('generator_generate_fab'),
-                  heroTag: 'generator_generate_fab',
-                  onPressed: () => context.read<GeneratorBloc>().add(
-                    const GeneratorRequested(),
-                  ),
-                  child: const Icon(LucideIcons.refreshCw),
-                ),
-              ),
-            ),
-          ],
-        ),
+    return AppFeatureShell(
+      title: context.l10n.passwordGenerator,
+      floatingActionButton: FloatingActionButton(
+        key: const Key('generator_generate_fab'),
+        heroTag: 'generator_generate_fab',
+        onPressed: _handleGenerate,
+        backgroundColor: context.colorScheme.primary,
+        foregroundColor: context.colorScheme.onPrimary,
+        child: Icon(
+          LucideIcons.refreshCw,
+          key: ValueKey(_refreshTick),
+          size: AppIconSize.l,
+        ).animate().rotate(duration: 650.ms, curve: Curves.easeOutCubic),
       ),
+      bodyWrapper: (context, child) {
+        return BlocListener<SettingsBloc, SettingsState>(
+          listenWhen: (previous, current) =>
+              previous.passwordSettings != current.passwordSettings,
+          listener: (context, state) {
+            context.read<GeneratorBloc>().add(const GeneratorStarted());
+          },
+          child: child,
+        );
+      },
+      slivers: [
+        BlocBuilder<GeneratorBloc, GeneratorState>(
+          builder: (context, state) {
+            return switch (state) {
+              GeneratorLoading() => const SliverFillRemaining(
+                child: Center(child: AppLoader()),
+              ),
+              GeneratorLoaded() => _GeneratorContentSliver(state: state),
+            };
+          },
+        ),
+      ],
     );
   }
 }

--- a/lib/features/generator/presentation/widgets/generator_control_widgets.dart
+++ b/lib/features/generator/presentation/widgets/generator_control_widgets.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:passvault/core/design_system/theme/theme.dart';
+
+class LengthStepperButton extends StatelessWidget {
+  final IconData icon;
+  final bool isEnabled;
+  final VoidCallback onTap;
+
+  const LengthStepperButton({
+    super.key,
+    required this.icon,
+    required this.isEnabled,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      onPressed: isEnabled ? onTap : null,
+      icon: Icon(icon, size: AppIconSize.m),
+      visualDensity: VisualDensity.compact,
+    );
+  }
+}
+
+class GeneratorToggleTile extends StatelessWidget {
+  final String label;
+  final String? subtitle;
+  final bool value;
+  final ValueChanged<bool> onChanged;
+
+  const GeneratorToggleTile({
+    super.key,
+    required this.label,
+    this.subtitle,
+    required this.value,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SwitchListTile(
+      title: Text(label),
+      subtitle: subtitle == null ? null : Text(subtitle!),
+      value: value,
+      onChanged: onChanged,
+      contentPadding: EdgeInsets.zero,
+      dense: true,
+      visualDensity: const VisualDensity(vertical: -2),
+    );
+  }
+}

--- a/lib/features/generator/presentation/widgets/generator_sections.dart
+++ b/lib/features/generator/presentation/widgets/generator_sections.dart
@@ -1,10 +1,14 @@
+import 'package:animations/animations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_animate/flutter_animate.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:passvault/core/design_system/components/components.dart';
 import 'package:passvault/core/design_system/theme/theme.dart';
 import 'package:passvault/features/generator/presentation/bloc/generator/generator_bloc.dart';
+import 'package:passvault/features/generator/presentation/widgets/password_feedback_view.dart';
+import 'package:passvault/features/generator/presentation/widgets/password_generation_controls_card.dart';
 import 'package:passvault/features/settings/domain/entities/password_generation_settings.dart';
 
 class GeneratorGeneratedPasswordCard extends StatelessWidget {
@@ -16,55 +20,100 @@ class GeneratorGeneratedPasswordCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = context.theme;
     final l10n = context.l10n;
+    final colorScheme = context.colorScheme;
     final password = state.generatedPassword.isEmpty
         ? l10n.hintPassword
         : state.generatedPassword;
-    return AppCard(
-      hasGlow: context.isAmoled,
-      padding: const EdgeInsets.all(AppSpacing.l),
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(minHeight: 40, maxHeight: 150),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          spacing: AppSpacing.m,
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Align(
-              alignment: Alignment.centerRight,
-              child: PasswordStrengthWidget(strength: state.strength),
-            ),
-            Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Expanded(
-                  child: SelectableText(
-                    password,
-                    minLines: 1,
-                    maxLines: 5,
-                    style: theme.passwordText.copyWith(
-                      fontSize: 22,
-                      fontWeight: FontWeight.w600,
-                      color: theme.primary,
-                      height: 1,
-                      overflow: TextOverflow.ellipsis,
+    return RepaintBoundary(
+      child: AppCard(
+        hasGlow: context.isAmoled,
+        padding: const EdgeInsets.all(AppSpacing.l),
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(minHeight: 40),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            spacing: AppSpacing.m,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Align(
+                alignment: Alignment.centerRight,
+                child: PasswordStrengthWidget(strength: state.strength),
+              ),
+              PasswordFeedbackView(feedback: state.strength),
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Expanded(
+                    child: SizedBox(
+                      height: 76,
+                      child: PageTransitionSwitcher(
+                        duration: const Duration(milliseconds: 320),
+                        layoutBuilder: (entries) => Stack(children: entries),
+                        transitionBuilder:
+                            (child, primaryAnimation, secondaryAnimation) =>
+                                SharedAxisTransition(
+                                  animation: primaryAnimation,
+                                  secondaryAnimation: secondaryAnimation,
+                                  transitionType:
+                                      SharedAxisTransitionType.vertical,
+                                  fillColor: colorScheme.surface.withValues(
+                                    alpha: 0,
+                                  ),
+                                  child: child,
+                                ),
+                        child: Align(
+                          key: ValueKey(password),
+                          alignment: Alignment.centerLeft,
+                          child:
+                              SelectableText(
+                                    password,
+                                    minLines: 1,
+                                    maxLines: 2,
+                                    style: theme.passwordText.copyWith(
+                                      fontSize: 22,
+                                      fontWeight: FontWeight.w600,
+                                      color: theme.primary,
+                                      height: 1.2,
+                                      overflow: TextOverflow.ellipsis,
+                                    ),
+                                  )
+                                  .animate(key: ValueKey(password))
+                                  .fadeIn(
+                                    duration: 320.ms,
+                                    curve: Curves.easeOut,
+                                  )
+                                  .slideX(
+                                    begin: 0.08,
+                                    end: 0,
+                                    duration: 320.ms,
+                                    curve: Curves.easeOutQuad,
+                                  )
+                                  .shimmer(
+                                    delay: 250.ms,
+                                    duration: 850.ms,
+                                    color: theme.onSurface.withValues(
+                                      alpha: 0.22,
+                                    ),
+                                  ),
+                        ),
+                      ),
                     ),
                   ),
-                ),
-
-                IconButton(
-                  key: const Key('generator_copy_icon_button'),
-                  tooltip: l10n.copyPassword,
-                  onPressed: state.generatedPassword.isEmpty
-                      ? null
-                      : () => _copyPassword(
-                          context,
-                          password: state.generatedPassword,
-                        ),
-                  icon: const Icon(LucideIcons.copy),
-                ),
-              ],
-            ),
-          ],
+                  IconButton(
+                    key: const Key('generator_copy_icon_button'),
+                    tooltip: l10n.copyPassword,
+                    onPressed: state.generatedPassword.isEmpty
+                        ? null
+                        : () => _copyPassword(
+                            context,
+                            password: state.generatedPassword,
+                          ),
+                    icon: const Icon(LucideIcons.copy),
+                  ),
+                ],
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -124,6 +173,12 @@ class GeneratorControlsCard extends StatelessWidget {
           onExcludeAmbiguousChanged: (value) => context
               .read<GeneratorBloc>()
               .add(GeneratorExcludeAmbiguousToggled(value)),
+          onWordCountChanged: (count) => context.read<GeneratorBloc>().add(
+            GeneratorWordCountChanged(count),
+          ),
+          onSeparatorChanged: (separator) => context.read<GeneratorBloc>().add(
+            GeneratorSeparatorChanged(separator),
+          ),
         ),
       ],
     );
@@ -159,181 +214,6 @@ class _GeneratorStrategyDropdown extends StatelessWidget {
         return DropdownMenuItem(value: strategy.id, child: Text(strategy.name));
       }).toList(),
       onChanged: onChanged,
-    );
-  }
-}
-
-class PasswordGenerationControlsCard extends StatelessWidget {
-  final PasswordGenerationStrategy strategy;
-  final String controlsPrefix;
-  final ValueChanged<int> onLengthChanged;
-  final ValueChanged<bool> onUppercaseChanged;
-  final ValueChanged<bool> onLowercaseChanged;
-  final ValueChanged<bool> onNumbersChanged;
-  final ValueChanged<bool> onSymbolsChanged;
-  final ValueChanged<bool> onExcludeAmbiguousChanged;
-
-  const PasswordGenerationControlsCard({
-    super.key,
-    required this.strategy,
-    required this.controlsPrefix,
-    required this.onLengthChanged,
-    required this.onUppercaseChanged,
-    required this.onLowercaseChanged,
-    required this.onNumbersChanged,
-    required this.onSymbolsChanged,
-    required this.onExcludeAmbiguousChanged,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final l10n = context.l10n;
-    final length = strategy.length;
-    final canDecrease = length > 16;
-    final canIncrease = length < 64;
-
-    return AppCard(
-      hasGlow: context.isAmoled,
-      padding: const EdgeInsets.all(AppSpacing.l),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              Expanded(
-                child: Text(
-                  l10n.lengthLabel,
-                  style: context.typography.labelMedium,
-                ),
-              ),
-              DecoratedBox(
-                decoration: BoxDecoration(
-                  color: context.theme.primaryContainer,
-                  borderRadius: BorderRadius.circular(AppRadius.m),
-                ),
-                child: Row(
-                  children: [
-                    LengthStepperButton(
-                      key: Key('${controlsPrefix}_length_decrease'),
-                      icon: LucideIcons.minus,
-                      isEnabled: canDecrease,
-                      onTap: () => onLengthChanged(length - 1),
-                    ),
-                    const SizedBox(width: AppSpacing.xs),
-                    Container(
-                      key: Key('${controlsPrefix}_length_badge'),
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: AppSpacing.m,
-                        vertical: AppSpacing.xs,
-                      ),
-                      decoration: BoxDecoration(
-                        color: context.theme.primaryContainer,
-                        borderRadius: BorderRadius.circular(AppRadius.full),
-                      ),
-                      child: Text(
-                        length.toString(),
-                        style: context.typography.labelMedium?.copyWith(
-                          color: context.theme.onPrimaryContainer,
-                          fontWeight: FontWeight.bold,
-                        ),
-                      ),
-                    ),
-                    const SizedBox(width: AppSpacing.xs),
-                    LengthStepperButton(
-                      key: Key('${controlsPrefix}_length_increase'),
-                      icon: LucideIcons.plus,
-                      isEnabled: canIncrease,
-                      onTap: () => onLengthChanged(length + 1),
-                    ),
-                  ],
-                ),
-              ),
-            ],
-          ),
-          const Divider(height: AppSpacing.l),
-          GeneratorToggleTile(
-            key: Key('${controlsPrefix}_uppercase_toggle'),
-            label: l10n.uppercaseLabel,
-            value: strategy.useUppercase,
-            onChanged: onUppercaseChanged,
-          ),
-          GeneratorToggleTile(
-            key: Key('${controlsPrefix}_lowercase_toggle'),
-            label: l10n.lowercaseLabel,
-            value: strategy.useLowercase,
-            onChanged: onLowercaseChanged,
-          ),
-          GeneratorToggleTile(
-            key: Key('${controlsPrefix}_numbers_toggle'),
-            label: l10n.numbersLabel,
-            value: strategy.useNumbers,
-            onChanged: onNumbersChanged,
-          ),
-          GeneratorToggleTile(
-            key: Key('${controlsPrefix}_symbols_toggle'),
-            label: l10n.symbolsLabel,
-            value: strategy.useSpecialChars,
-            onChanged: onSymbolsChanged,
-          ),
-          GeneratorToggleTile(
-            key: Key('${controlsPrefix}_exclude_ambiguous_toggle'),
-            label: l10n.excludeAmbiguous,
-            subtitle: l10n.excludeAmbiguousHint,
-            value: strategy.excludeAmbiguousChars,
-            onChanged: onExcludeAmbiguousChanged,
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class LengthStepperButton extends StatelessWidget {
-  final IconData icon;
-  final bool isEnabled;
-  final VoidCallback onTap;
-
-  const LengthStepperButton({
-    super.key,
-    required this.icon,
-    required this.isEnabled,
-    required this.onTap,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return IconButton(
-      onPressed: isEnabled ? onTap : null,
-      icon: Icon(icon, size: AppIconSize.m),
-      visualDensity: VisualDensity.compact,
-    );
-  }
-}
-
-class GeneratorToggleTile extends StatelessWidget {
-  final String label;
-  final String? subtitle;
-  final bool value;
-  final ValueChanged<bool> onChanged;
-
-  const GeneratorToggleTile({
-    super.key,
-    required this.label,
-    this.subtitle,
-    required this.value,
-    required this.onChanged,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return SwitchListTile(
-      title: Text(label),
-      subtitle: subtitle == null ? null : Text(subtitle!),
-      value: value,
-      onChanged: onChanged,
-      contentPadding: EdgeInsets.zero,
-      dense: true,
-      visualDensity: const VisualDensity(vertical: -2),
     );
   }
 }

--- a/lib/features/generator/presentation/widgets/password_feedback_view.dart
+++ b/lib/features/generator/presentation/widgets/password_feedback_view.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:passvault/core/design_system/theme/theme.dart';
+import 'package:passvault/features/password_manager/domain/entities/password_feedback.dart';
+
+class PasswordFeedbackView extends StatelessWidget {
+  final PasswordFeedback feedback;
+
+  const PasswordFeedbackView({super.key, required this.feedback});
+
+  bool get _hasContent =>
+      (feedback.warning?.isNotEmpty ?? false) ||
+      feedback.suggestions.isNotEmpty;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_hasContent) {
+      return const SizedBox.shrink();
+    }
+
+    final typography = context.typography;
+    final theme = context.theme;
+
+    return Container(
+      width: double.infinity,
+      margin: const EdgeInsets.only(top: AppSpacing.m),
+      padding: const EdgeInsets.all(AppSpacing.m),
+      decoration: BoxDecoration(
+        color: theme.warning.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(AppRadius.m),
+        border: Border.all(color: theme.warning.withValues(alpha: 0.35)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        spacing: AppSpacing.s,
+        children: [
+          if (feedback.warning?.isNotEmpty ?? false)
+            Text(
+              feedback.warning!,
+              style: typography.bodySmall?.copyWith(
+                color: theme.onSurface,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ...feedback.suggestions
+              .take(3)
+              .map(
+                (suggestion) => Text(
+                  suggestion,
+                  style: typography.bodySmall?.copyWith(
+                    color: theme.onSurface.withValues(alpha: 0.85),
+                  ),
+                ),
+              ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/generator/presentation/widgets/password_generation_controls_card.dart
+++ b/lib/features/generator/presentation/widgets/password_generation_controls_card.dart
@@ -1,0 +1,256 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_animate/flutter_animate.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
+import 'package:passvault/core/design_system/components/components.dart';
+import 'package:passvault/core/design_system/theme/theme.dart';
+import 'package:passvault/features/generator/presentation/widgets/generator_control_widgets.dart';
+import 'package:passvault/features/settings/domain/entities/password_generation_settings.dart';
+import 'package:passvault/features/settings/domain/entities/password_strategy_type.dart';
+
+class PasswordGenerationControlsCard extends StatelessWidget {
+  final PasswordGenerationStrategy strategy;
+  final String controlsPrefix;
+  final ValueChanged<int> onLengthChanged;
+  final ValueChanged<bool> onUppercaseChanged;
+  final ValueChanged<bool> onLowercaseChanged;
+  final ValueChanged<bool> onNumbersChanged;
+  final ValueChanged<bool> onSymbolsChanged;
+  final ValueChanged<bool> onExcludeAmbiguousChanged;
+  final ValueChanged<int> onWordCountChanged;
+  final ValueChanged<String> onSeparatorChanged;
+
+  const PasswordGenerationControlsCard({
+    super.key,
+    required this.strategy,
+    required this.controlsPrefix,
+    required this.onLengthChanged,
+    required this.onUppercaseChanged,
+    required this.onLowercaseChanged,
+    required this.onNumbersChanged,
+    required this.onSymbolsChanged,
+    required this.onExcludeAmbiguousChanged,
+    required this.onWordCountChanged,
+    required this.onSeparatorChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final length = strategy.length;
+    final isRandom = strategy.type == PasswordStrategyType.random;
+
+    return AppCard(
+      hasGlow: context.isAmoled,
+      padding: const EdgeInsets.all(AppSpacing.l),
+      child: AnimatedSize(
+        duration: const Duration(milliseconds: 300),
+        curve: Curves.easeInOut,
+        alignment: Alignment.topCenter,
+        child:
+            Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    if (isRandom) ...[
+                      Row(
+                        children: [
+                          Expanded(
+                            child: Text(
+                              l10n.lengthLabel,
+                              style: context.typography.labelMedium,
+                            ),
+                          ),
+                          _CountStepper(
+                            decreaseKey: Key(
+                              '${controlsPrefix}_length_decrease',
+                            ),
+                            increaseKey: Key(
+                              '${controlsPrefix}_length_increase',
+                            ),
+                            badgeKey: Key('${controlsPrefix}_length_badge'),
+                            value: length,
+                            min: 16,
+                            max: 64,
+                            onChanged: onLengthChanged,
+                          ),
+                        ],
+                      ),
+                      const Divider(height: AppSpacing.l),
+                      GeneratorToggleTile(
+                        key: Key('${controlsPrefix}_uppercase_toggle'),
+                        label: l10n.uppercaseLabel,
+                        value: strategy.useUppercase,
+                        onChanged: onUppercaseChanged,
+                      ),
+                      GeneratorToggleTile(
+                        key: Key('${controlsPrefix}_lowercase_toggle'),
+                        label: l10n.lowercaseLabel,
+                        value: strategy.useLowercase,
+                        onChanged: onLowercaseChanged,
+                      ),
+                      GeneratorToggleTile(
+                        key: Key('${controlsPrefix}_numbers_toggle'),
+                        label: l10n.numbersLabel,
+                        value: strategy.useNumbers,
+                        onChanged: onNumbersChanged,
+                      ),
+                      GeneratorToggleTile(
+                        key: Key('${controlsPrefix}_symbols_toggle'),
+                        label: l10n.symbolsLabel,
+                        value: strategy.useSpecialChars,
+                        onChanged: onSymbolsChanged,
+                      ),
+                      GeneratorToggleTile(
+                        key: Key('${controlsPrefix}_exclude_ambiguous_toggle'),
+                        label: l10n.excludeAmbiguous,
+                        subtitle: l10n.excludeAmbiguousHint,
+                        value: strategy.excludeAmbiguousChars,
+                        onChanged: onExcludeAmbiguousChanged,
+                      ),
+                    ] else ...[
+                      Row(
+                        children: [
+                          Expanded(
+                            child: Text(
+                              l10n.wordCountLabel,
+                              style: context.typography.labelMedium,
+                            ),
+                          ),
+                          _CountStepper(
+                            decreaseKey: Key(
+                              '${controlsPrefix}_word_count_decrease',
+                            ),
+                            increaseKey: Key(
+                              '${controlsPrefix}_word_count_increase',
+                            ),
+                            badgeKey: Key('${controlsPrefix}_word_count_badge'),
+                            value: strategy.wordCount,
+                            min: 3,
+                            max: 10,
+                            onChanged: onWordCountChanged,
+                          ),
+                        ],
+                      ),
+                      const Divider(height: AppSpacing.l),
+                      Row(
+                        children: [
+                          Expanded(
+                            child: Text(
+                              l10n.separatorLabel,
+                              style: context.typography.labelMedium,
+                            ),
+                          ),
+                          DropdownButton<String>(
+                            value: strategy.separator,
+                            items: _separatorOptions.map((separator) {
+                              return DropdownMenuItem(
+                                value: separator,
+                                child: Text(
+                                  separator.isEmpty
+                                      ? l10n.separatorNone
+                                      : separator,
+                                ),
+                              );
+                            }).toList(),
+                            onChanged: (value) {
+                              if (value != null) {
+                                onSeparatorChanged(value);
+                              }
+                            },
+                          ),
+                        ],
+                      ),
+                      const Divider(height: AppSpacing.l),
+                      GeneratorToggleTile(
+                        key: Key(
+                          '${controlsPrefix}_memorable_uppercase_toggle',
+                        ),
+                        label: l10n.uppercaseLabel,
+                        value: strategy.useUppercase,
+                        onChanged: onUppercaseChanged,
+                      ),
+                      GeneratorToggleTile(
+                        key: Key(
+                          '${controlsPrefix}_memorable_lowercase_toggle',
+                        ),
+                        label: l10n.lowercaseLabel,
+                        value: strategy.useLowercase,
+                        onChanged: onLowercaseChanged,
+                      ),
+                    ],
+                  ],
+                )
+                .animate()
+                .fadeIn(duration: 300.ms, curve: Curves.easeOut)
+                .slideX(begin: 0.05, end: 0, curve: Curves.easeOutQuad),
+      ),
+    );
+  }
+}
+
+class _CountStepper extends StatelessWidget {
+  final Key decreaseKey;
+  final Key increaseKey;
+  final Key badgeKey;
+  final int value;
+  final int min;
+  final int max;
+  final ValueChanged<int> onChanged;
+
+  const _CountStepper({
+    required this.decreaseKey,
+    required this.increaseKey,
+    required this.badgeKey,
+    required this.value,
+    required this.min,
+    required this.max,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: context.theme.primaryContainer,
+        borderRadius: BorderRadius.circular(AppRadius.m),
+      ),
+      child: Row(
+        children: [
+          LengthStepperButton(
+            key: decreaseKey,
+            icon: LucideIcons.minus,
+            isEnabled: value > min,
+            onTap: () => onChanged(value - 1),
+          ),
+          const SizedBox(width: AppSpacing.xs),
+          Container(
+            key: badgeKey,
+            padding: const EdgeInsets.symmetric(
+              horizontal: AppSpacing.m,
+              vertical: AppSpacing.xs,
+            ),
+            decoration: BoxDecoration(
+              color: context.theme.primaryContainer,
+              borderRadius: BorderRadius.circular(AppRadius.full),
+            ),
+            child: Text(
+              value.toString(),
+              style: context.typography.labelMedium?.copyWith(
+                color: context.theme.onPrimaryContainer,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
+          const SizedBox(width: AppSpacing.xs),
+          LengthStepperButton(
+            key: increaseKey,
+            icon: LucideIcons.plus,
+            isEnabled: value < max,
+            onTap: () => onChanged(value + 1),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+const List<String> _separatorOptions = ['-', '_', '.', ' ', ''];

--- a/lib/features/settings/presentation/screens/strategy_editor.dart
+++ b/lib/features/settings/presentation/screens/strategy_editor.dart
@@ -1,16 +1,16 @@
+import 'package:animations/animations.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_animate/flutter_animate.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
-import 'package:passvault/core/design_system/theme/app_dimensions.dart';
-import 'package:passvault/core/design_system/theme/app_theme_extension.dart';
-import 'package:passvault/features/generator/presentation/widgets/generator_sections.dart';
+import 'package:passvault/core/design_system/theme/theme.dart';
+import 'package:passvault/features/generator/presentation/widgets/password_generation_controls_card.dart';
 import 'package:passvault/features/settings/domain/entities/password_generation_settings.dart';
-
+import 'package:passvault/features/settings/domain/entities/password_strategy_type.dart';
 import '../widgets/strategy_preview_card.dart';
 
 class StrategyEditor extends StatefulWidget {
   final PasswordGenerationStrategy strategy;
   final ValueChanged<PasswordGenerationStrategy> onChanged;
-
   const StrategyEditor({
     super.key,
     required this.strategy,
@@ -22,8 +22,8 @@ class StrategyEditor extends StatefulWidget {
 }
 
 class _StrategyEditorState extends State<StrategyEditor> {
+  static const double _controlsMinHeight = 360;
   late TextEditingController _nameController;
-
   @override
   void initState() {
     super.initState();
@@ -49,32 +49,79 @@ class _StrategyEditorState extends State<StrategyEditor> {
   @override
   Widget build(BuildContext context) {
     final settings = widget.strategy;
-
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       spacing: AppSpacing.xl,
       children: [
+        _StrategyTypeSelector(
+          type: settings.type,
+          onChanged: (value) =>
+              widget.onChanged(settings.copyWith(type: value)),
+        ),
         StrategyPreviewCard(settings: settings),
         _StrategyNameInput(
           controller: _nameController,
           onChanged: (value) =>
               widget.onChanged(settings.copyWith(name: value)),
         ),
-        PasswordGenerationControlsCard(
-          strategy: settings,
-          controlsPrefix: 'strategy_editor',
-          onLengthChanged: (value) =>
-              widget.onChanged(settings.copyWith(length: value)),
-          onUppercaseChanged: (value) =>
-              widget.onChanged(settings.copyWith(useUppercase: value)),
-          onLowercaseChanged: (value) =>
-              widget.onChanged(settings.copyWith(useLowercase: value)),
-          onNumbersChanged: (value) =>
-              widget.onChanged(settings.copyWith(useNumbers: value)),
-          onSymbolsChanged: (value) =>
-              widget.onChanged(settings.copyWith(useSpecialChars: value)),
-          onExcludeAmbiguousChanged: (value) =>
-              widget.onChanged(settings.copyWith(excludeAmbiguousChars: value)),
+        ClipRect(
+          child: AnimatedSize(
+            duration: const Duration(milliseconds: 280),
+            curve: Curves.easeOutCubic,
+            alignment: Alignment.topCenter,
+            child: PageTransitionSwitcher(
+              duration: const Duration(milliseconds: 400),
+              reverse: settings.type == PasswordStrategyType.random,
+              layoutBuilder: (entries) => Stack(children: entries),
+              transitionBuilder: (child, primaryAnimation, secondaryAnimation) {
+                return SharedAxisTransition(
+                  animation: primaryAnimation,
+                  secondaryAnimation: secondaryAnimation,
+                  transitionType: SharedAxisTransitionType.horizontal,
+                  fillColor: context.colorScheme.surface.withValues(alpha: 0),
+                  child: child,
+                );
+              },
+              child:
+                  ConstrainedBox(
+                        key: ValueKey(settings.type),
+                        constraints: const BoxConstraints(
+                          minHeight: _controlsMinHeight,
+                        ),
+                        child: PasswordGenerationControlsCard(
+                          strategy: settings,
+                          controlsPrefix: 'strategy_editor',
+                          onLengthChanged: (value) => widget.onChanged(
+                            settings.copyWith(length: value),
+                          ),
+                          onUppercaseChanged: (value) => widget.onChanged(
+                            settings.copyWith(useUppercase: value),
+                          ),
+                          onLowercaseChanged: (value) => widget.onChanged(
+                            settings.copyWith(useLowercase: value),
+                          ),
+                          onNumbersChanged: (value) => widget.onChanged(
+                            settings.copyWith(useNumbers: value),
+                          ),
+                          onSymbolsChanged: (value) => widget.onChanged(
+                            settings.copyWith(useSpecialChars: value),
+                          ),
+                          onExcludeAmbiguousChanged: (value) =>
+                              widget.onChanged(
+                                settings.copyWith(excludeAmbiguousChars: value),
+                              ),
+                          onWordCountChanged: (value) => widget.onChanged(
+                            settings.copyWith(wordCount: value),
+                          ),
+                          onSeparatorChanged: (value) => widget.onChanged(
+                            settings.copyWith(separator: value),
+                          ),
+                        ),
+                      )
+                      .animate(key: ValueKey(settings.type))
+                      .fadeIn(duration: 300.ms, curve: Curves.easeOut),
+            ),
+          ),
         ),
       ],
     );
@@ -84,41 +131,169 @@ class _StrategyEditorState extends State<StrategyEditor> {
 class _StrategyNameInput extends StatelessWidget {
   final TextEditingController controller;
   final ValueChanged<String> onChanged;
-
   const _StrategyNameInput({required this.controller, required this.onChanged});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = context.theme;
+    final colorScheme = context.colorScheme;
+    final textTheme = context.typography;
+    return TextField(
+          controller: controller,
+          style: textTheme.bodyLarge?.copyWith(
+            fontWeight: FontWeight.w600,
+            color: colorScheme.onSurface,
+          ),
+          decoration: InputDecoration(
+            labelText: context.l10n.strategyName,
+            labelStyle: textTheme.labelMedium?.copyWith(
+              color: colorScheme.onSurfaceVariant,
+            ),
+            hintText: context.l10n.hintStrategyName,
+            border: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(AppRadius.l),
+              borderSide: BorderSide(
+                color: colorScheme.outline.withValues(alpha: 0.3),
+              ),
+            ),
+            enabledBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(AppRadius.l),
+              borderSide: BorderSide(
+                color: colorScheme.outline.withValues(alpha: 0.1),
+              ),
+            ),
+            focusedBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(AppRadius.l),
+              borderSide: BorderSide(color: theme.primary, width: 2),
+            ),
+            prefixIcon: Icon(
+              LucideIcons.tag,
+              color: theme.primary.withValues(alpha: 0.7),
+              size: 20,
+            ),
+            filled: true,
+            fillColor: colorScheme.surfaceContainerLow,
+            contentPadding: const EdgeInsets.symmetric(
+              horizontal: AppSpacing.l,
+              vertical: AppSpacing.m,
+            ),
+          ),
+          onChanged: onChanged,
+        )
+        .animate()
+        .fadeIn(duration: 400.ms, curve: Curves.easeOut)
+        .slideY(
+          begin: 0.1,
+          end: 0,
+          duration: 400.ms,
+          curve: Curves.easeOutQuad,
+        );
+  }
+}
+
+class _StrategyTypeSelector extends StatelessWidget {
+  final PasswordStrategyType type;
+  final ValueChanged<PasswordStrategyType> onChanged;
+
+  const _StrategyTypeSelector({required this.type, required this.onChanged});
 
   @override
   Widget build(BuildContext context) {
     final l10n = context.l10n;
     final theme = context.theme;
-    final colorScheme = context.colorScheme;
-    final textTheme = context.typography;
 
-    return TextField(
-      controller: controller,
-      style: textTheme.bodyLarge?.copyWith(fontWeight: FontWeight.w500),
-      decoration: InputDecoration(
-        labelText: l10n.strategyName,
-        hintText: l10n.hintStrategyName,
-        border: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(AppRadius.l),
-          borderSide: BorderSide(color: colorScheme.outline),
+    return SegmentedButton<PasswordStrategyType>(
+      style: SegmentedButton.styleFrom(
+        backgroundColor: context.colorScheme.surfaceContainerLow,
+        selectedBackgroundColor: theme.primary.withValues(alpha: 0.15),
+        selectedForegroundColor: theme.primary,
+        side: BorderSide(
+          color: context.colorScheme.outline.withValues(alpha: 0.1),
         ),
-        enabledBorder: OutlineInputBorder(
+        shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(AppRadius.l),
-          borderSide: BorderSide(
-            color: colorScheme.outline.withValues(alpha: 0.2),
+        ),
+        padding: const EdgeInsets.symmetric(vertical: AppSpacing.s),
+      ),
+      segments: [
+        ButtonSegment(
+          value: PasswordStrategyType.random,
+          label: _SegmentLabel(
+            title: l10n.randomStrategyTitle,
+            subtitle: l10n.randomStrategySubtitle,
+            icon: LucideIcons.shuffle,
+            isSelected: type == PasswordStrategyType.random,
           ),
         ),
-        focusedBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(AppRadius.l),
-          borderSide: BorderSide(color: theme.primary, width: 2),
+        ButtonSegment(
+          value: PasswordStrategyType.memorable,
+          label: _SegmentLabel(
+            title: l10n.memorableStrategyTitle,
+            subtitle: l10n.memorableStrategySubtitle,
+            icon: LucideIcons.languages,
+            isSelected: type == PasswordStrategyType.memorable,
+          ),
         ),
-        prefixIcon: Icon(LucideIcons.tag, color: colorScheme.onSurfaceVariant),
-        filled: true,
-        fillColor: colorScheme.surfaceContainerLow.withValues(alpha: 0.5),
+      ],
+      selected: {type},
+      onSelectionChanged: (Set<PasswordStrategyType> newSelection) {
+        onChanged(newSelection.first);
+      },
+      showSelectedIcon: false,
+    );
+  }
+}
+
+class _SegmentLabel extends StatelessWidget {
+  final String title;
+  final String subtitle;
+  final IconData icon;
+  final bool isSelected;
+
+  const _SegmentLabel({
+    required this.title,
+    required this.subtitle,
+    required this.icon,
+    required this.isSelected,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = context.typography;
+    final theme = context.theme;
+    final l10n = context.l10n;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 18),
+          const SizedBox(width: AppSpacing.s),
+          Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                title,
+                style: textTheme.labelLarge?.copyWith(
+                  fontWeight: FontWeight.bold,
+                  color: isSelected ? theme.primary : null,
+                ),
+              ),
+              Text(
+                l10n.strategyTypeSubtitle(subtitle),
+                style: textTheme.bodySmall?.copyWith(
+                  fontSize: 10,
+                  color: isSelected
+                      ? theme.primary.withValues(alpha: 0.7)
+                      : null,
+                ),
+              ),
+            ],
+          ),
+        ],
       ),
-      onChanged: onChanged,
     );
   }
 }

--- a/lib/features/settings/presentation/screens/strategy_editor_screen.dart
+++ b/lib/features/settings/presentation/screens/strategy_editor_screen.dart
@@ -107,23 +107,21 @@ class _StrategyEditorScreenState extends State<StrategyEditorScreen> {
     return BlocBuilder<SettingsBloc, SettingsState>(
       builder: (context, state) {
         return Scaffold(
-          bottomNavigationBar: PersistentBottomBar(
-            scrollController: _scrollController,
-            child: FloatingActionButton.extended(
-              key: const Key('strategy_editor_save_fab'),
-              heroTag: 'strategy_editor_save_fab',
-              onPressed: state is SettingsLoading ? null : _saveStrategy,
-              backgroundColor: theme.primary,
-              foregroundColor: theme.onPrimary,
-              icon: state is SettingsLoading
-                  ? const SizedBox(
-                      width: AppIconSize.m,
-                      height: AppIconSize.m,
-                      child: AppLoader(key: Key('strategy_editor_loader')),
-                    )
-                  : const Icon(LucideIcons.save),
-              label: Text(l10n.save),
-            ),
+          extendBody: true,
+          floatingActionButton: FloatingActionButton.extended(
+            key: const Key('strategy_editor_save_fab'),
+            heroTag: 'strategy_editor_save_fab',
+            onPressed: state is SettingsLoading ? null : _saveStrategy,
+            backgroundColor: theme.primary,
+            foregroundColor: theme.onPrimary,
+            icon: state is SettingsLoading
+                ? const SizedBox(
+                    width: AppIconSize.m,
+                    height: AppIconSize.m,
+                    child: AppLoader(key: Key('strategy_editor_loader')),
+                  )
+                : const Icon(LucideIcons.save),
+            label: Text(l10n.save),
           ),
           body: CustomScrollView(
             controller: _scrollController,
@@ -158,6 +156,9 @@ class _StrategyEditorScreenState extends State<StrategyEditorScreen> {
                     },
                   ),
                 ),
+              ),
+              const SliverToBoxAdapter(
+                child: SizedBox(height: AppDimensions.fabBottomPadding),
               ),
             ],
           ),

--- a/lib/features/settings/presentation/screens/strategy_screen.dart
+++ b/lib/features/settings/presentation/screens/strategy_screen.dart
@@ -20,7 +20,10 @@ class StrategyScreen extends StatelessWidget {
     final l10n = context.l10n;
     final theme = context.theme;
 
-    return Scaffold(
+    return AppFeatureShell(
+      title: l10n.strategy,
+      showBack: true,
+      onBack: () => context.pop(),
       backgroundColor: theme.background,
       floatingActionButton: FloatingActionButton(
         key: const Key('add_strategy_fab'),
@@ -30,53 +33,53 @@ class StrategyScreen extends StatelessWidget {
         },
         child: const Icon(LucideIcons.plus),
       ),
-      body: BlocBuilder<SettingsBloc, SettingsState>(
-        builder: (context, state) {
-          final settings = state.passwordSettings;
-
-          return CustomScrollView(
-            slivers: [
-              SliverToBoxAdapter(
-                child: SafeArea(
-                  bottom: false,
-                  child: Padding(
-                    padding: const EdgeInsets.fromLTRB(
-                      AppSpacing.l,
-                      AppSpacing.m,
-                      AppSpacing.l,
-                      AppSpacing.s,
-                    ),
-                    child: PageHeader(
-                      title: l10n.strategy,
-                      showBack: true,
-                      onBack: () => context.pop(),
-                    ),
-                  ),
-                ),
-              ),
-              if (settings.strategies.isEmpty)
-                EmptyStrategiesPlaceholder(l10n: l10n, theme: theme)
-              else ...[
-                ActiveStrategySection(
-                  settings: settings,
-                  l10n: l10n,
-                  onEdit: (strategy) => _showEditor(context, strategy.id),
-                ),
-                if (settings.strategies.length > 1)
-                  SavedStrategiesSection(
-                    settings: settings,
-                    l10n: l10n,
-                    onEdit: (strategy) => _showEditor(context, strategy.id),
-                  ),
-              ],
-            ],
-          );
-        },
-      ),
+      slivers: [
+        _StrategyContentSliver(
+          onEdit: (strategyId) => _showEditor(context, strategyId),
+        ),
+      ],
     );
   }
 
   void _showEditor(BuildContext context, String strategyId) {
     context.push(AppRoutes.strategyEditor, extra: {'strategyId': strategyId});
+  }
+}
+
+class _StrategyContentSliver extends StatelessWidget {
+  final ValueChanged<String> onEdit;
+
+  const _StrategyContentSliver({required this.onEdit});
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final theme = context.theme;
+
+    return BlocBuilder<SettingsBloc, SettingsState>(
+      builder: (context, state) {
+        final settings = state.passwordSettings;
+
+        if (settings.strategies.isEmpty) {
+          return EmptyStrategiesPlaceholder(l10n: l10n, theme: theme);
+        }
+
+        return SliverMainAxisGroup(
+          slivers: [
+            ActiveStrategySection(
+              settings: settings,
+              l10n: l10n,
+              onEdit: (strategy) => onEdit(strategy.id),
+            ),
+            if (settings.strategies.length > 1)
+              SavedStrategiesSection(
+                settings: settings,
+                l10n: l10n,
+                onEdit: (strategy) => onEdit(strategy.id),
+              ),
+          ],
+        );
+      },
+    );
   }
 }

--- a/lib/features/settings/presentation/settings_screen.dart
+++ b/lib/features/settings/presentation/settings_screen.dart
@@ -6,10 +6,10 @@ import 'package:passvault/config/routes/app_routes.dart';
 import 'package:passvault/core/design_system/components/components.dart';
 import 'package:passvault/core/design_system/theme/theme.dart';
 import 'package:passvault/features/password_manager/presentation/bloc/import_export/import_export_bloc.dart';
-import 'package:passvault/features/settings/domain/entities/theme_type.dart';
 import 'package:passvault/features/settings/presentation/bloc/locale/locale_bloc.dart';
 import 'package:passvault/features/settings/presentation/bloc/settings/settings_bloc.dart';
 import 'package:passvault/features/settings/presentation/bloc/theme/theme_bloc.dart';
+import 'package:passvault/features/settings/presentation/settings_screen_helpers.dart';
 import 'package:passvault/features/settings/presentation/widgets/password_protected_dialog.dart';
 import 'package:passvault/features/settings/presentation/widgets/settings_panels.dart';
 
@@ -131,8 +131,8 @@ class SettingsScreen extends StatelessWidget {
                       key: const Key('settings_theme_tile'),
                       icon: LucideIcons.moon,
                       label: l10n.theme,
-                      trailing: Text(_getThemeName(currentThemeType, l10n)),
-                      onTap: () => _showThemePicker(
+                      trailing: Text(themeDisplayName(currentThemeType, l10n)),
+                      onTap: () => showThemePickerSheet(
                         context,
                         currentThemeType: currentThemeType,
                         l10n: l10n,
@@ -142,8 +142,8 @@ class SettingsScreen extends StatelessWidget {
                       key: const Key('settings_language_tile'),
                       icon: LucideIcons.languages,
                       label: l10n.language,
-                      trailing: Text(_localeDisplayName(currentLocale, l10n)),
-                      onTap: () => _showLanguagePicker(
+                      trailing: Text(localeDisplayName(currentLocale, l10n)),
+                      onTap: () => showLanguagePickerSheet(
                         context,
                         selectedLocale: localeOverride,
                         l10n: l10n,
@@ -202,7 +202,7 @@ class SettingsScreen extends StatelessWidget {
                       label: l10n.clearDatabase,
                       labelColor: theme.error,
                       iconColor: theme.error,
-                      onTap: () => _showClearDatabaseDialog(context),
+                      onTap: () => showClearDatabaseDialog(context),
                     ),
                   ],
                 ),
@@ -220,89 +220,6 @@ class SettingsScreen extends StatelessWidget {
             ),
           ],
         ),
-      ),
-    );
-  }
-
-  String _getThemeName(ThemeType type, AppLocalizations l10n) {
-    return switch (type) {
-      ThemeType.system => l10n.system,
-      ThemeType.light => l10n.light,
-      ThemeType.dark => l10n.dark,
-      ThemeType.amoled => l10n.amoled,
-    };
-  }
-
-  String _localeDisplayName(Locale locale, AppLocalizations l10n) {
-    return switch (locale.languageCode) {
-      'en' => l10n.english,
-      _ => locale.toLanguageTag(),
-    };
-  }
-
-  void _showThemePicker(
-    BuildContext context, {
-    required ThemeType currentThemeType,
-    required AppLocalizations l10n,
-  }) {
-    final themeBloc = context.read<ThemeBloc>();
-    showModalBottomSheet(
-      context: context,
-      shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(top: Radius.circular(AppRadius.xl)),
-      ),
-      builder: (context) => ThemePickerSheet(
-        currentThemeType: currentThemeType,
-        onThemeSelected: (themeType) => themeBloc.add(ThemeChanged(themeType)),
-        l10n: l10n,
-      ),
-    );
-  }
-
-  void _showLanguagePicker(
-    BuildContext context, {
-    required Locale? selectedLocale,
-    required AppLocalizations l10n,
-  }) {
-    final localeBloc = context.read<LocaleBloc>();
-    showModalBottomSheet(
-      context: context,
-      shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(top: Radius.circular(AppRadius.xl)),
-      ),
-      builder: (context) => LocalePickerSheet(
-        selectedLocale: selectedLocale,
-        onLocaleSelected: (locale) => localeBloc.add(ChangeLocale(locale)),
-        onSystemLocaleSelected: () => localeBloc.add(const SetSystemLocale()),
-        l10n: l10n,
-      ),
-    );
-  }
-
-  void _showClearDatabaseDialog(BuildContext context) {
-    final bloc = context.read<ImportExportBloc>();
-    final l10n = context.l10n;
-    final theme = context.theme;
-
-    showDialog(
-      context: context,
-      builder: (dialogContext) => AlertDialog(
-        title: Text(l10n.clearDatabaseTitle),
-        content: Text(l10n.clearDatabaseMessage),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(dialogContext),
-            child: Text(l10n.cancel, style: TextStyle(color: theme.onSurface)),
-          ),
-          TextButton(
-            onPressed: () {
-              Navigator.pop(dialogContext);
-              bloc.add(const ClearDatabaseEvent());
-            },
-            style: TextButton.styleFrom(foregroundColor: theme.error),
-            child: Text(l10n.clearAll),
-          ),
-        ],
       ),
     );
   }

--- a/lib/features/settings/presentation/settings_screen_helpers.dart
+++ b/lib/features/settings/presentation/settings_screen_helpers.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:passvault/core/design_system/theme/theme.dart';
+import 'package:passvault/features/password_manager/presentation/bloc/import_export/import_export_bloc.dart';
+import 'package:passvault/features/settings/domain/entities/theme_type.dart';
+import 'package:passvault/features/settings/presentation/bloc/locale/locale_bloc.dart';
+import 'package:passvault/features/settings/presentation/bloc/theme/theme_bloc.dart';
+import 'package:passvault/features/settings/presentation/widgets/settings_panels.dart';
+
+String themeDisplayName(ThemeType type, AppLocalizations l10n) {
+  return switch (type) {
+    ThemeType.system => l10n.system,
+    ThemeType.light => l10n.light,
+    ThemeType.dark => l10n.dark,
+    ThemeType.amoled => l10n.amoled,
+  };
+}
+
+String localeDisplayName(Locale locale, AppLocalizations l10n) {
+  return switch (locale.languageCode) {
+    'en' => l10n.english,
+    _ => locale.toLanguageTag(),
+  };
+}
+
+void showThemePickerSheet(
+  BuildContext context, {
+  required ThemeType currentThemeType,
+  required AppLocalizations l10n,
+}) {
+  final themeBloc = context.read<ThemeBloc>();
+  showModalBottomSheet(
+    context: context,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(top: Radius.circular(AppRadius.xl)),
+    ),
+    builder: (context) => ThemePickerSheet(
+      currentThemeType: currentThemeType,
+      onThemeSelected: (themeType) => themeBloc.add(ThemeChanged(themeType)),
+      l10n: l10n,
+    ),
+  );
+}
+
+void showLanguagePickerSheet(
+  BuildContext context, {
+  required Locale? selectedLocale,
+  required AppLocalizations l10n,
+}) {
+  final localeBloc = context.read<LocaleBloc>();
+  showModalBottomSheet(
+    context: context,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(top: Radius.circular(AppRadius.xl)),
+    ),
+    builder: (context) => LocalePickerSheet(
+      selectedLocale: selectedLocale,
+      onLocaleSelected: (locale) => localeBloc.add(ChangeLocale(locale)),
+      onSystemLocaleSelected: () => localeBloc.add(const SetSystemLocale()),
+      l10n: l10n,
+    ),
+  );
+}
+
+void showClearDatabaseDialog(BuildContext context) {
+  final bloc = context.read<ImportExportBloc>();
+  final l10n = context.l10n;
+  final theme = context.theme;
+
+  showDialog(
+    context: context,
+    builder: (dialogContext) => AlertDialog(
+      title: Text(l10n.clearDatabaseTitle),
+      content: Text(l10n.clearDatabaseMessage),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(dialogContext),
+          child: Text(l10n.cancel, style: TextStyle(color: theme.onSurface)),
+        ),
+        TextButton(
+          onPressed: () {
+            Navigator.pop(dialogContext);
+            bloc.add(const ClearDatabaseEvent());
+          },
+          style: TextButton.styleFrom(foregroundColor: theme.error),
+          child: Text(l10n.clearAll),
+        ),
+      ],
+    ),
+  );
+}

--- a/lib/features/settings/presentation/widgets/strategy_preview_card.dart
+++ b/lib/features/settings/presentation/widgets/strategy_preview_card.dart
@@ -1,6 +1,10 @@
+import 'package:animations/animations.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_animate/flutter_animate.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
+import 'package:passvault/core/design_system/components/common/password_strength_widget.dart';
+import 'package:passvault/core/design_system/components/feedback/app_loader.dart';
 import 'package:passvault/core/design_system/theme/theme.dart';
 import 'package:passvault/core/di/injection.dart';
 import 'package:passvault/features/settings/domain/entities/password_generation_settings.dart';
@@ -71,7 +75,10 @@ class _PreviewCardEffectState extends State<_PreviewCardEffect> {
       final oldS = oldWidget.settings;
       final newS = widget.settings;
       bool shouldRegenerate =
+          oldS.type != newS.type ||
           oldS.length != newS.length ||
+          oldS.wordCount != newS.wordCount ||
+          oldS.separator != newS.separator ||
           oldS.useNumbers != newS.useNumbers ||
           oldS.useSpecialChars != newS.useSpecialChars ||
           oldS.useUppercase != newS.useUppercase ||
@@ -105,66 +112,177 @@ class _PreviewCardView extends StatelessWidget {
   Widget build(BuildContext context) {
     final l10n = context.l10n;
     final theme = context.theme;
+    final textTheme = context.typography;
     final colorScheme = context.colorScheme;
 
-    return Container(
-      width: double.infinity,
-      padding: const EdgeInsets.all(AppSpacing.l),
-      decoration: BoxDecoration(
-        color: colorScheme.surfaceContainer,
-        borderRadius: BorderRadius.circular(AppRadius.xl),
-        boxShadow: [
-          theme.cardShadow,
-          BoxShadow(
-            color: theme.primary.withValues(alpha: 0.05),
-            blurRadius: 20,
-            offset: const Offset(0, 0),
-          ),
-        ],
-        border: Border.all(
-          color: theme.primary.withValues(alpha: 0.1),
-          width: 1.5,
+    return RepaintBoundary(
+      child: Container(
+        width: double.infinity,
+        decoration: BoxDecoration(
+          gradient: theme.vaultGradient,
+          borderRadius: BorderRadius.circular(AppRadius.xl),
+          boxShadow: [
+            theme.cardShadow,
+            BoxShadow(
+              color: theme.primary.withValues(alpha: 0.15),
+              blurRadius: 30,
+              spreadRadius: -5,
+            ),
+          ],
         ),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        child: Padding(
+          padding: const EdgeInsets.all(AppSpacing.xl),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text(
-                l10n.preview.toUpperCase(),
-                style: context.typography.labelSmall?.copyWith(
-                  color: colorScheme.onSurfaceVariant,
-                  fontWeight: FontWeight.bold,
-                  letterSpacing: 1.5,
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Text(
+                    l10n.preview.toUpperCase(),
+                    style: textTheme.labelSmall?.copyWith(
+                      color: theme.onVaultGradient.withValues(alpha: 0.7),
+                      fontWeight: FontWeight.w800,
+                      letterSpacing: 2,
+                    ),
+                  ),
+                  _RefreshButton(
+                    onTap: onRefresh,
+                    color: theme.onVaultGradient,
+                    isLoading: state is StrategyPreviewLoading,
+                  ),
+                ],
+              ),
+              const SizedBox(height: AppSpacing.xl),
+              SizedBox(
+                height: 76,
+                child: PageTransitionSwitcher(
+                  duration: const Duration(milliseconds: 350),
+                  layoutBuilder: (entries) => Stack(children: entries),
+                  transitionBuilder:
+                      (child, primaryAnimation, secondaryAnimation) =>
+                          SharedAxisTransition(
+                            animation: primaryAnimation,
+                            secondaryAnimation: secondaryAnimation,
+                            transitionType: SharedAxisTransitionType.vertical,
+                            fillColor: colorScheme.surface.withValues(alpha: 0),
+                            child: child,
+                          ),
+                  child: state is StrategyPreviewLoading
+                      ? const Align(
+                          key: ValueKey('preview_loader_shell'),
+                          alignment: Alignment.centerLeft,
+                          child: SizedBox(
+                            height: 40,
+                            child: Center(
+                              child: AppLoader(
+                                key: ValueKey('preview_loader'),
+                                size: AppIconSize.m,
+                              ),
+                            ),
+                          ),
+                        )
+                      : Align(
+                          key: ValueKey('preview_text_${state.password}'),
+                          alignment: Alignment.centerLeft,
+                          child:
+                              SelectableText(
+                                    state.password,
+                                    maxLines: 2,
+                                    style: theme.passwordText.copyWith(
+                                      fontSize: 22,
+                                      color: theme.onVaultGradient,
+                                      height: 1.4,
+                                    ),
+                                  )
+                                  .animate(key: ValueKey(state.password))
+                                  .fadeIn(
+                                    duration: 400.ms,
+                                    curve: Curves.easeOut,
+                                  )
+                                  .slideX(
+                                    begin: 0.08,
+                                    end: 0,
+                                    duration: 400.ms,
+                                    curve: Curves.easeOutQuad,
+                                  )
+                                  .shimmer(
+                                    delay: 400.ms,
+                                    duration: 900.ms,
+                                    color: theme.onVaultGradient.withValues(
+                                      alpha: 0.24,
+                                    ),
+                                  ),
+                        ),
                 ),
               ),
-              InkWell(
-                onTap: onRefresh,
-                borderRadius: BorderRadius.circular(AppRadius.full),
-                child: Padding(
-                  padding: const EdgeInsets.all(AppSpacing.xs),
-                  child: Icon(
-                    LucideIcons.refreshCw,
-                    color: theme.primary,
-                    size: 16,
-                  ),
+              const SizedBox(height: AppSpacing.xl),
+              Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: AppSpacing.m,
+                  vertical: AppSpacing.s,
+                ),
+                decoration: BoxDecoration(
+                  color: theme.surface.withValues(alpha: 0.2),
+                  borderRadius: BorderRadius.circular(AppRadius.m),
+                ),
+                child: PasswordStrengthWidget(
+                  strength: state.strength,
+                  labelColor: theme.onVaultGradient,
                 ),
               ),
             ],
           ),
-          const SizedBox(height: AppSpacing.m),
-          SelectableText(
-            state.password,
-            style: context.typography.headlineSmall?.copyWith(
-              fontFamily: 'monospace',
-              fontWeight: FontWeight.bold,
-              color: colorScheme.onSurface,
-              letterSpacing: 0.5,
-            ),
+        ),
+      ),
+    );
+  }
+}
+
+class _RefreshButton extends StatelessWidget {
+  final VoidCallback onTap;
+  final Color color;
+  final bool isLoading;
+
+  const _RefreshButton({
+    required this.onTap,
+    required this.color,
+    this.isLoading = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = context.colorScheme;
+
+    return Material(
+      color: colorScheme.surface.withValues(alpha: 0),
+      child: InkWell(
+        key: const Key('strategy_preview_refresh_button'),
+        onTap: isLoading ? null : onTap,
+        borderRadius: BorderRadius.circular(AppRadius.full),
+        child: Container(
+          width: 34,
+          height: 34,
+          decoration: BoxDecoration(
+            color: color.withValues(alpha: 0.18),
+            shape: BoxShape.circle,
+            border: Border.all(color: color.withValues(alpha: 0.35)),
+            boxShadow: [
+              BoxShadow(
+                color: color.withValues(alpha: 0.2),
+                blurRadius: 8,
+                spreadRadius: 0.5,
+              ),
+            ],
           ),
-        ],
+          child: Icon(LucideIcons.refreshCw, color: color, size: 18)
+              .animate(
+                target: isLoading ? 1 : 0,
+                onPlay: (controller) => controller.repeat(),
+              )
+              .rotate(duration: 1.seconds)
+              .fadeIn(duration: 200.ms),
+        ),
       ),
     );
   }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -159,5 +159,22 @@
   "notSelectedState": "not selected",
   "savePassword": "Save Password",
   "updatePassword": "Update Password",
-  "entryNotFound": "Password entry not found"
+  "entryNotFound": "Password entry not found",
+  "wordCountLabel": "Word Count",
+  "separatorLabel": "Separator",
+  "separatorNone": "None",
+  "memorableStrategy": "Memorable (Passphrase)",
+  "randomStrategy": "Random (Characters)",
+  "randomStrategyTitle": "Random",
+  "randomStrategySubtitle": "Characters",
+  "memorableStrategyTitle": "Memorable",
+  "memorableStrategySubtitle": "Passphrase",
+  "strategyTypeSubtitle": "({value})",
+  "@strategyTypeSubtitle": {
+    "placeholders": {
+      "value": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -885,6 +885,66 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Password entry not found'**
   String get entryNotFound;
+
+  /// No description provided for @wordCountLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Word Count'**
+  String get wordCountLabel;
+
+  /// No description provided for @separatorLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Separator'**
+  String get separatorLabel;
+
+  /// No description provided for @separatorNone.
+  ///
+  /// In en, this message translates to:
+  /// **'None'**
+  String get separatorNone;
+
+  /// No description provided for @memorableStrategy.
+  ///
+  /// In en, this message translates to:
+  /// **'Memorable (Passphrase)'**
+  String get memorableStrategy;
+
+  /// No description provided for @randomStrategy.
+  ///
+  /// In en, this message translates to:
+  /// **'Random (Characters)'**
+  String get randomStrategy;
+
+  /// No description provided for @randomStrategyTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Random'**
+  String get randomStrategyTitle;
+
+  /// No description provided for @randomStrategySubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Characters'**
+  String get randomStrategySubtitle;
+
+  /// No description provided for @memorableStrategyTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Memorable'**
+  String get memorableStrategyTitle;
+
+  /// No description provided for @memorableStrategySubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Passphrase'**
+  String get memorableStrategySubtitle;
+
+  /// No description provided for @strategyTypeSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'({value})'**
+  String strategyTypeSubtitle(String value);
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -420,4 +420,36 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get entryNotFound => 'Password entry not found';
+
+  @override
+  String get wordCountLabel => 'Word Count';
+
+  @override
+  String get separatorLabel => 'Separator';
+
+  @override
+  String get separatorNone => 'None';
+
+  @override
+  String get memorableStrategy => 'Memorable (Passphrase)';
+
+  @override
+  String get randomStrategy => 'Random (Characters)';
+
+  @override
+  String get randomStrategyTitle => 'Random';
+
+  @override
+  String get randomStrategySubtitle => 'Characters';
+
+  @override
+  String get memorableStrategyTitle => 'Memorable';
+
+  @override
+  String get memorableStrategySubtitle => 'Passphrase';
+
+  @override
+  String strategyTypeSubtitle(String value) {
+    return '($value)';
+  }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -17,6 +17,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.4.1"
+  animations:
+    dependency: "direct main"
+    description:
+      name: animations
+      sha256: "18938cefd7dcc04e1ecac0db78973761a01e4bc2d6bfae0cfa596bfeac9e96ab"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
   archive:
     dependency: transitive
     description:
@@ -310,6 +318,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_animate:
+    dependency: "direct main"
+    description:
+      name: flutter_animate
+      sha256: "7befe2d3252728afb77aecaaea1dec88a89d35b9b1d2eea6d04479e8af9117b5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.5.2"
   flutter_bloc:
     dependency: "direct main"
     description:
@@ -395,6 +411,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.0"
+  flutter_shaders:
+    dependency: transitive
+    description:
+      name: flutter_shaders
+      sha256: "34794acadd8275d971e02df03afee3dee0f98dbfb8c4837082ad0034f612a3e2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.3"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -52,6 +52,8 @@ dependencies:
 
   # Animations & Utilities
   lottie: ^3.3.2
+  flutter_animate: ^4.5.2
+  animations: ^2.0.11
   share_plus: ^12.0.1
   file_picker: ^10.3.8
   file_saver: ^0.3.1

--- a/test/core/design_system/components/common/app_filter_chips_test.dart
+++ b/test/core/design_system/components/common/app_filter_chips_test.dart
@@ -4,11 +4,12 @@ import 'package:passvault/core/design_system/components/common/app_filter_chips.
 import '../../../../helpers/test_helpers.dart';
 
 void main() {
-  const labels = ['All', 'Recently Added', 'Most Used', 'Favorites'];
   late AppLocalizations l10n;
+  late List<String> labels;
 
   setUpAll(() async {
     l10n = await getL10n();
+    labels = [l10n.vault, l10n.generator, l10n.settings, l10n.security];
   });
 
   group('$AppFilterChips', () {
@@ -27,13 +28,13 @@ void main() {
     ) async {
       await tester.pumpApp(
         AppFilterChips(
-          labels: const ['All'],
+          labels: [labels.first],
           selectedIndex: 0,
           onSelected: (_) {},
         ),
       );
 
-      expect(find.text('All'), findsOneWidget);
+      expect(find.text(labels.first), findsOneWidget);
     });
 
     testWidgets('calls onSelected with correct index when tapped', (
@@ -49,7 +50,7 @@ void main() {
         ),
       );
 
-      await tester.tap(find.text('Most Used'));
+      await tester.tap(find.text(labels[2]));
       await tester.pumpAndSettle();
 
       expect(tappedIndex, 2);
@@ -58,12 +59,10 @@ void main() {
     testWidgets('does not crash when onSelected is null', (
       WidgetTester tester,
     ) async {
-      await tester.pumpApp(
-        const AppFilterChips(labels: labels, selectedIndex: 0),
-      );
+      await tester.pumpApp(AppFilterChips(labels: labels, selectedIndex: 0));
 
       // Should not throw
-      await tester.tap(find.text('Favorites'));
+      await tester.tap(find.text(labels[3]));
       await tester.pumpAndSettle();
     });
 
@@ -86,7 +85,7 @@ void main() {
         AppFilterChips(labels: labels, selectedIndex: 0, onSelected: (_) {}),
       );
 
-      await tester.tap(find.text('Recently Added'));
+      await tester.tap(find.text(labels[1]));
       await tester.pumpAndSettle();
 
       expect(
@@ -112,10 +111,10 @@ void main() {
         AppFilterChips(labels: labels, selectedIndex: 0, onSelected: (_) {}),
       );
 
-      final selectedSemantics = tester.getSemantics(find.text('All'));
+      final selectedSemantics = tester.getSemantics(find.text(labels.first));
       expect(
         selectedSemantics.label,
-        contains(l10n.filterChipSemantics('All')),
+        contains(l10n.filterChipSemantics(labels.first)),
       );
       expect(selectedSemantics.label, contains(l10n.selectedState));
     });
@@ -127,12 +126,10 @@ void main() {
         AppFilterChips(labels: labels, selectedIndex: 0, onSelected: (_) {}),
       );
 
-      final unselectedSemantics = tester.getSemantics(
-        find.text('Recently Added'),
-      );
+      final unselectedSemantics = tester.getSemantics(find.text(labels[1]));
       expect(
         unselectedSemantics.label,
-        contains(l10n.filterChipSemantics('Recently Added')),
+        contains(l10n.filterChipSemantics(labels[1])),
       );
       expect(unselectedSemantics.label, isNot(contains(l10n.selectedState)));
     });
@@ -164,7 +161,10 @@ void main() {
     });
 
     testWidgets('handles many chips (scrollable)', (WidgetTester tester) async {
-      final manyLabels = List.generate(20, (i) => 'Category $i');
+      final manyLabels = List.generate(
+        20,
+        (i) => '${l10n.passwordGenerator} $i',
+      );
 
       await tester.pumpApp(
         AppFilterChips(
@@ -175,20 +175,25 @@ void main() {
       );
 
       // First chips visible
-      expect(find.text('Category 0'), findsOneWidget);
+      expect(find.text(manyLabels.first), findsOneWidget);
 
       // Later chips exist in widget tree but may be off-screen
-      expect(find.text('Category 19'), findsOneWidget);
+      expect(find.text(manyLabels.last), findsOneWidget);
     });
 
     testWidgets('handles long label with ellipsis', (
       WidgetTester tester,
     ) async {
-      const longLabel = 'This is a very long filter label that should truncate';
+      final longLabel = [
+        l10n.passwordGenerator,
+        l10n.passwordGenerator,
+        l10n.passwordGenerator,
+        l10n.passwordGenerator,
+      ].join(' ');
 
       await tester.pumpApp(
         AppFilterChips(
-          labels: [longLabel, 'Short'],
+          labels: [longLabel, l10n.save],
           selectedIndex: 0,
           onSelected: (_) {},
         ),

--- a/test/features/generator/presentation/generator_screen_test.dart
+++ b/test/features/generator/presentation/generator_screen_test.dart
@@ -2,6 +2,7 @@ import 'package:passvault/features/generator/presentation/bloc/generator/generat
 import 'package:passvault/features/generator/presentation/generator_screen.dart';
 import 'package:passvault/features/password_manager/domain/entities/password_feedback.dart';
 import 'package:passvault/features/settings/domain/entities/password_generation_settings.dart';
+import 'package:passvault/features/settings/domain/entities/password_strategy_type.dart';
 import 'package:passvault/features/settings/presentation/bloc/settings/settings_bloc.dart';
 import 'package:password_engine/password_engine.dart' show PasswordStrength;
 
@@ -43,16 +44,47 @@ void main() {
     defaultStrategyId: 'strategy',
   );
 
+  const memorableStrategy = PasswordGenerationStrategy(
+    id: 'memorable',
+    name: 'Memorable',
+    type: PasswordStrategyType.memorable,
+    wordCount: 4,
+    separator: '-',
+    useUppercase: true,
+    useLowercase: true,
+  );
+
+  const memorableSettings = PasswordGenerationSettings(
+    strategies: [memorableStrategy, strategy],
+    defaultStrategyId: 'memorable',
+  );
+
   const loadedState = GeneratorLoaded(
     strategy: strategy,
     generatedPassword: 'Abc123\$%',
-    strength: PasswordFeedback(strength: PasswordStrength.strong),
+    strength: PasswordFeedback(
+      strength: PasswordStrength.strong,
+      score: 80,
+      entropy: 64,
+    ),
     settings: settings,
+  );
+
+  const memorableState = GeneratorLoaded(
+    strategy: memorableStrategy,
+    generatedPassword: 'phone-road-correct-garden',
+    strength: PasswordFeedback(strength: PasswordStrength.medium),
+    settings: memorableSettings,
   );
 
   const settingsState = SettingsLoaded(
     useBiometrics: false,
     passwordSettings: settings,
+  );
+
+  const memorableSettingsState = SettingsLoaded(
+    useBiometrics: false,
+    passwordSettings: memorableSettings,
   );
 
   setUpAll(() async {
@@ -162,6 +194,50 @@ void main() {
       verify(
         () => mockGeneratorBloc.add(const GeneratorStrategySelected('another')),
       ).called(1);
+    });
+
+    testWidgets('renders feedback warning and suggestions for weak passwords', (
+      tester,
+    ) async {
+      final warning = l10n.warningSensitiveData;
+      final suggestionOne = l10n.encryptWithPassword;
+      final suggestionTwo = l10n.exportNow;
+      final feedbackState = GeneratorLoaded(
+        strategy: strategy,
+        generatedPassword: 'weak-password',
+        strength: PasswordFeedback(
+          strength: PasswordStrength.weak,
+          warning: warning,
+          suggestions: [suggestionOne, suggestionTwo],
+        ),
+        settings: settings,
+      );
+
+      when(() => mockGeneratorBloc.state).thenReturn(feedbackState);
+      await loadScreen(tester);
+
+      expect(find.text(warning), findsOneWidget);
+      expect(find.text(suggestionOne), findsOneWidget);
+      expect(find.text(suggestionTwo), findsOneWidget);
+    });
+
+    testWidgets('shows memorable controls with capitalization toggles', (
+      tester,
+    ) async {
+      when(() => mockGeneratorBloc.state).thenReturn(memorableState);
+      when(() => mockSettingsBloc.state).thenReturn(memorableSettingsState);
+      await loadScreen(tester);
+
+      expect(find.text(l10n.wordCountLabel), findsOneWidget);
+      expect(find.text(l10n.separatorLabel), findsOneWidget);
+      expect(
+        find.byKey(const Key('generator_memorable_uppercase_toggle')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('generator_memorable_lowercase_toggle')),
+        findsOneWidget,
+      );
     });
   });
 }

--- a/test/features/generator/presentation/widgets/generator_control_widgets_test.dart
+++ b/test/features/generator/presentation/widgets/generator_control_widgets_test.dart
@@ -1,0 +1,85 @@
+import 'package:passvault/features/generator/presentation/widgets/generator_control_widgets.dart';
+
+import '../../../../helpers/test_helpers.dart';
+
+void main() {
+  group('$LengthStepperButton', () {
+    testWidgets('renders icon and calls onTap when enabled', (tester) async {
+      var tapped = false;
+      await tester.pumpApp(
+        LengthStepperButton(
+          icon: Icons.add,
+          isEnabled: true,
+          onTap: () => tapped = true,
+        ),
+      );
+
+      expect(find.byIcon(Icons.add), findsOneWidget);
+
+      await tester.tap(find.byType(IconButton));
+      await tester.pump();
+
+      expect(tapped, isTrue);
+    });
+
+    testWidgets('does not call onTap when disabled', (tester) async {
+      var tapped = false;
+      await tester.pumpApp(
+        LengthStepperButton(
+          icon: Icons.remove,
+          isEnabled: false,
+          onTap: () => tapped = true,
+        ),
+      );
+
+      await tester.tap(find.byType(IconButton));
+      await tester.pump();
+
+      expect(tapped, isFalse);
+    });
+  });
+
+  group('$GeneratorToggleTile', () {
+    testWidgets('renders label and toggle switch', (tester) async {
+      await tester.pumpApp(
+        GeneratorToggleTile(
+          label: 'Test Label',
+          value: true,
+          onChanged: (_) {},
+        ),
+      );
+
+      expect(find.text('Test Label'), findsOneWidget);
+      expect(find.byType(Switch), findsOneWidget);
+    });
+
+    testWidgets('renders subtitle when provided', (tester) async {
+      await tester.pumpApp(
+        GeneratorToggleTile(
+          label: 'Label',
+          subtitle: 'Subtitle Text',
+          value: false,
+          onChanged: (_) {},
+        ),
+      );
+
+      expect(find.text('Subtitle Text'), findsOneWidget);
+    });
+
+    testWidgets('calls onChanged when toggled', (tester) async {
+      bool? changedValue;
+      await tester.pumpApp(
+        GeneratorToggleTile(
+          label: 'Toggle',
+          value: false,
+          onChanged: (value) => changedValue = value,
+        ),
+      );
+
+      await tester.tap(find.byType(Switch));
+      await tester.pump();
+
+      expect(changedValue, isTrue);
+    });
+  });
+}

--- a/test/features/home/presentation/bloc/password_bloc_test.dart
+++ b/test/features/home/presentation/bloc/password_bloc_test.dart
@@ -39,7 +39,6 @@ void main() {
     mockDeletePassword = MockDeletePasswordUseCase();
     mockRepository = MockPasswordRepository();
 
-    // Mock the dataChanges stream to return empty stream
     when(
       () => mockRepository.dataChanges,
     ).thenAnswer((_) => const Stream<void>.empty());
@@ -95,7 +94,6 @@ void main() {
       ],
       verify: (_) {
         verify(() => mockSavePassword(any())).called(1);
-        // Verify that getPasswords was NOT called (incremental update)
         verifyNever(() => mockGetPasswords());
       },
     );
@@ -249,7 +247,6 @@ void main() {
       test(
         'listens to repository dataChanges and fires LoadPasswords',
         () async {
-          // We need a proper StreamController to emit events
           final controller = StreamController<void>();
           when(
             () => mockRepository.dataChanges,
@@ -258,7 +255,6 @@ void main() {
             () => mockGetPasswords(),
           ).thenAnswer((_) async => Success([tEntry]));
 
-          // Re-init bloc to pick up the mocked stream
           final testBloc = PasswordBloc(
             mockGetPasswords,
             mockSavePassword,
@@ -266,7 +262,6 @@ void main() {
             mockRepository,
           );
 
-          // Emit an event on the stream and wait for bloc to process it
           controller.add(null);
           await Future.delayed(Duration.zero);
 
@@ -284,7 +279,6 @@ void main() {
           mockRepository,
         );
         await b.close();
-        // Just verify it doesn't crash on close
         expect(b.state, isA<PasswordState>());
       });
     });

--- a/test/features/password_manager/presentation/bloc/import_export/import_export_bloc_actions_and_props_test.dart
+++ b/test/features/password_manager/presentation/bloc/import_export/import_export_bloc_actions_and_props_test.dart
@@ -1,0 +1,205 @@
+import 'dart:typed_data';
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:passvault/core/error/failures.dart';
+import 'package:passvault/core/error/result.dart';
+import 'package:passvault/core/services/biometric_service.dart';
+import 'package:passvault/core/services/data_service.dart';
+import 'package:passvault/core/services/file_picker_service.dart';
+import 'package:passvault/core/services/file_service.dart';
+import 'package:passvault/features/password_manager/domain/entities/duplicate_password_entry.dart';
+import 'package:passvault/features/password_manager/domain/entities/password_entry.dart';
+import 'package:passvault/features/password_manager/domain/repositories/password_repository.dart';
+import 'package:passvault/features/password_manager/domain/usecases/clear_all_passwords_usecase.dart';
+import 'package:passvault/features/password_manager/domain/usecases/import_passwords_usecase.dart';
+import 'package:passvault/features/password_manager/domain/usecases/resolve_duplicates_usecase.dart';
+import 'package:passvault/features/password_manager/presentation/bloc/import_export/import_export_bloc.dart';
+
+class MockBiometricService extends Mock implements BiometricService {}
+
+class MockImportPasswordsUseCase extends Mock
+    implements ImportPasswordsUseCase {}
+
+class MockResolveDuplicatesUseCase extends Mock
+    implements ResolveDuplicatesUseCase {}
+
+class MockClearAllPasswordsUseCase extends Mock
+    implements ClearAllPasswordsUseCase {}
+
+class MockPasswordRepository extends Mock implements PasswordRepository {}
+
+class MockDataService extends Mock implements DataService {}
+
+class MockFileService extends Mock implements FileService {}
+
+class MockFilePickerService extends Mock implements IFilePickerService {}
+
+void main() {
+  late ImportExportBloc bloc;
+  late MockImportPasswordsUseCase mockImportUseCase;
+  late MockResolveDuplicatesUseCase mockResolveUseCase;
+  late MockClearAllPasswordsUseCase mockClearAllUseCase;
+  late MockPasswordRepository mockPasswordRepository;
+  late MockDataService mockDataService;
+  late MockFileService mockFileService;
+  late MockFilePickerService mockFilePickerService;
+  late MockBiometricService mockBiometricService;
+
+  final testEntries = [
+    PasswordEntry(
+      id: '1',
+      appName: 'Test App',
+      username: 'user',
+      password: 'password',
+      lastUpdated: DateTime(2024),
+    ),
+  ];
+
+  setUpAll(() {
+    registerFallbackValue(<PasswordEntry>[]);
+    registerFallbackValue(<DuplicatePasswordEntry>[]);
+    registerFallbackValue(Uint8List(0));
+  });
+
+  setUp(() {
+    mockImportUseCase = MockImportPasswordsUseCase();
+    mockResolveUseCase = MockResolveDuplicatesUseCase();
+    mockClearAllUseCase = MockClearAllPasswordsUseCase();
+    mockPasswordRepository = MockPasswordRepository();
+    mockDataService = MockDataService();
+    mockFileService = MockFileService();
+    mockFilePickerService = MockFilePickerService();
+    mockBiometricService = MockBiometricService();
+
+    when(
+      () => mockBiometricService.authenticate(
+        localizedReason: any(named: 'localizedReason'),
+      ),
+    ).thenAnswer((_) async => true);
+
+    bloc = ImportExportBloc(
+      mockImportUseCase,
+      mockResolveUseCase,
+      mockClearAllUseCase,
+      mockPasswordRepository,
+      mockDataService,
+      mockFileService,
+      mockFilePickerService,
+    );
+  });
+
+  tearDown(() => bloc.close());
+
+  group('$ImportExportBloc', () {
+    group('$ClearDatabaseEvent', () {
+      blocTest<ImportExportBloc, ImportExportState>(
+        'emits [Loading, ClearDatabaseSuccess] when successful',
+        build: () {
+          when(
+            () => mockClearAllUseCase(),
+          ).thenAnswer((_) async => const Success(null));
+          return bloc;
+        },
+        act: (bloc) => bloc.add(const ClearDatabaseEvent()),
+        expect: () => [
+          const ImportExportLoading(),
+          const ClearDatabaseSuccess(),
+        ],
+      );
+    });
+
+    group('$ResetMigrationStatus', () {
+      blocTest<ImportExportBloc, ImportExportState>(
+        'emits [Initial]',
+        build: () => bloc,
+        act: (bloc) => bloc.add(const ResetMigrationStatus()),
+        expect: () => [const ImportExportInitial()],
+      );
+    });
+
+    group('$ResolveDuplicatesEvent', () {
+      final duplicates = [
+        DuplicatePasswordEntry(
+          existingEntry: testEntries.first,
+          newEntry: testEntries.first,
+          conflictReason: 'reason',
+        ),
+      ];
+
+      blocTest<ImportExportBloc, ImportExportState>(
+        'emits [Loading, DuplicatesResolved] when resolutions are successful',
+        build: () {
+          when(
+            () => mockResolveUseCase(any()),
+          ).thenAnswer((_) async => const Success(null));
+          return bloc;
+        },
+        act: (bloc) => bloc.add(ResolveDuplicatesEvent(duplicates)),
+        expect: () => [
+          const ImportExportLoading(),
+          const DuplicatesResolved(totalResolved: 1, totalImported: 1),
+        ],
+      );
+
+      blocTest<ImportExportBloc, ImportExportState>(
+        'emits [Loading, Failure] when resolution fails',
+        build: () {
+          when(() => mockResolveUseCase(any())).thenAnswer(
+            (_) async => const Error(DataMigrationFailure('Failed')),
+          );
+          return bloc;
+        },
+        act: (bloc) => bloc.add(ResolveDuplicatesEvent(duplicates)),
+        expect: () => [
+          const ImportExportLoading(),
+          const ImportExportFailure(DataMigrationError.unknown, 'Failed'),
+        ],
+      );
+    });
+
+    group('ImportExportEvent props', () {
+      test('props are correct', () {
+        expect(const ExportDataEvent().props, [true]);
+        expect(const ExportEncryptedEvent('pass').props, ['pass']);
+        expect(const PrepareImportFromFileEvent().props, isEmpty);
+        expect(const ImportEncryptedEvent('pass', filePath: 'path').props, [
+          'pass',
+          'path',
+        ]);
+
+        final duplicates = [
+          DuplicatePasswordEntry(
+            existingEntry: testEntries.first,
+            newEntry: testEntries.first,
+            conflictReason: '',
+          ),
+        ];
+        expect(ResolveDuplicatesEvent(duplicates).props, [duplicates]);
+
+        expect(const ClearDatabaseEvent().props, isEmpty);
+        expect(const ResetMigrationStatus().props, isEmpty);
+      });
+    });
+
+    group('ImportExportState props', () {
+      test('props are correct', () {
+        expect(const ImportExportInitial().props, isEmpty);
+        expect(const ImportExportLoading().props, isEmpty);
+        expect(const ExportSuccess('path').props, ['path']);
+        expect(const ImportSuccess(1).props, [1]);
+        expect(const ImportEncryptedFileSelected('path').props, ['path']);
+        expect(
+          const DuplicatesResolved(totalResolved: 1, totalImported: 2).props,
+          [1, 2],
+        );
+        expect(const ClearDatabaseSuccess().props, isEmpty);
+        expect(
+          const ImportExportFailure(DataMigrationError.unknown, 'msg').props,
+          [DataMigrationError.unknown, 'msg'],
+        );
+      });
+    });
+  });
+}

--- a/test/features/password_manager/presentation/bloc/import_export/import_export_bloc_test.dart
+++ b/test/features/password_manager/presentation/bloc/import_export/import_export_bloc_test.dart
@@ -3,7 +3,6 @@ import 'dart:typed_data';
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:passvault/core/error/failures.dart';
 import 'package:passvault/core/error/result.dart';
 import 'package:passvault/core/services/biometric_service.dart';
 import 'package:passvault/core/services/data_service.dart';
@@ -280,116 +279,6 @@ void main() {
               'Please select a .json, .csv, or .pvault file',
             ),
           ],
-        );
-      });
-
-      group('$ClearDatabaseEvent', () {
-        blocTest<ImportExportBloc, ImportExportState>(
-          'emits [Loading, ClearDatabaseSuccess] when successful',
-          build: () {
-            when(
-              () => mockClearAllUseCase(),
-            ).thenAnswer((_) async => const Success(null));
-            return bloc;
-          },
-          act: (bloc) => bloc.add(const ClearDatabaseEvent()),
-          expect: () => [
-            const ImportExportLoading(),
-            const ClearDatabaseSuccess(),
-          ],
-        );
-      });
-
-      group('$ResetMigrationStatus', () {
-        blocTest<ImportExportBloc, ImportExportState>(
-          'emits [Initial]',
-          build: () => bloc,
-          act: (bloc) => bloc.add(const ResetMigrationStatus()),
-          expect: () => [const ImportExportInitial()],
-        );
-      });
-      group('$ResolveDuplicatesEvent', () {
-        final duplicates = [
-          DuplicatePasswordEntry(
-            existingEntry: testEntries.first,
-            newEntry: testEntries.first,
-            conflictReason: 'reason',
-          ),
-        ];
-
-        blocTest<ImportExportBloc, ImportExportState>(
-          'emits [Loading, DuplicatesResolved] when resolutions are successful',
-          build: () {
-            when(
-              () => mockResolveUseCase(any()),
-            ).thenAnswer((_) async => const Success(null));
-            return bloc;
-          },
-          act: (bloc) => bloc.add(ResolveDuplicatesEvent(duplicates)),
-          expect: () => [
-            // const ImportExportLoading('Authenticating...'), // Removed
-            const ImportExportLoading(),
-            const DuplicatesResolved(totalResolved: 1, totalImported: 1),
-          ],
-        );
-
-        blocTest<ImportExportBloc, ImportExportState>(
-          'emits [Loading, Failure] when resolution fails',
-          build: () {
-            when(() => mockResolveUseCase(any())).thenAnswer(
-              (_) async => const Error(DataMigrationFailure('Failed')),
-            );
-            return bloc;
-          },
-          act: (bloc) => bloc.add(ResolveDuplicatesEvent(duplicates)),
-          expect: () => [
-            // const ImportExportLoading('Authenticating...'), // Removed
-            const ImportExportLoading(),
-            const ImportExportFailure(DataMigrationError.unknown, 'Failed'),
-          ],
-        );
-      });
-    });
-
-    group('ImportExportEvent props', () {
-      test('props are correct', () {
-        expect(const ExportDataEvent().props, [true]);
-        expect(const ExportEncryptedEvent('pass').props, ['pass']);
-        expect(const PrepareImportFromFileEvent().props, isEmpty);
-        expect(const ImportEncryptedEvent('pass', filePath: 'path').props, [
-          'pass',
-          'path',
-        ]);
-
-        final duplicates = [
-          DuplicatePasswordEntry(
-            existingEntry: testEntries.first,
-            newEntry: testEntries.first,
-            conflictReason: '',
-          ),
-        ];
-        expect(ResolveDuplicatesEvent(duplicates).props, [duplicates]);
-
-        expect(const ClearDatabaseEvent().props, isEmpty);
-        expect(const ResetMigrationStatus().props, isEmpty);
-      });
-    });
-
-    group('ImportExportState props', () {
-      test('props are correct', () {
-        expect(const ImportExportInitial().props, isEmpty);
-        expect(const ImportExportLoading().props, isEmpty);
-        expect(const ExportSuccess('path').props, ['path']);
-        expect(const ImportSuccess(1).props, [1]);
-        expect(const ImportEncryptedFileSelected('path').props, ['path']);
-        expect(
-          const DuplicatesResolved(totalResolved: 1, totalImported: 2).props,
-          [1, 2],
-        );
-        expect(const ClearDatabaseSuccess().props, isEmpty);
-        expect(
-          const ImportExportFailure(DataMigrationError.unknown, 'msg').props,
-          [DataMigrationError.unknown, 'msg'],
         );
       });
     });

--- a/test/features/password_manager/presentation/widgets/duplicate_card_test.dart
+++ b/test/features/password_manager/presentation/widgets/duplicate_card_test.dart
@@ -24,7 +24,7 @@ void main() {
         id: 'new_id',
         password: 'new_password',
       ),
-      conflictReason: 'Username already exists',
+      conflictReason: l10n.resolveConflictsDesc,
     );
   });
 
@@ -43,7 +43,7 @@ void main() {
         find.textContaining(testDuplicate.existingEntry.username),
         findsOneWidget,
       );
-      expect(find.text('Username already exists'), findsOneWidget);
+      expect(find.text(testDuplicate.conflictReason), findsOneWidget);
     });
 
     testWidgets('calls onChoiceChanged when a resolution is selected', (

--- a/test/features/settings/presentation/screens/settings_screen_test.dart
+++ b/test/features/settings/presentation/screens/settings_screen_test.dart
@@ -147,41 +147,36 @@ void main() {
       ).called(1);
     });
 
-    testWidgets(
-      'Navigates to resolution screen on DuplicatesDetected',
-      skip: true,
-      (tester) async {
-        final mockDuplicate = MockDuplicatePasswordEntry();
-        final controller = StreamController<ImportExportState>.broadcast();
-        addTearDown(controller.close);
+    testWidgets('Navigates to resolution screen on DuplicatesDetected', (
+      tester,
+    ) async {
+      final mockDuplicate = MockDuplicatePasswordEntry();
+      final controller = StreamController<ImportExportState>.broadcast();
+      addTearDown(controller.close);
 
-        whenListen(
-          mockImportExportBloc,
-          controller.stream,
-          initialState: const ImportExportInitial(),
-        );
-        when(
-          () => mockGoRouter.push(any(), extra: any(named: 'extra')),
-        ).thenAnswer((_) async => null);
+      whenListen(
+        mockImportExportBloc,
+        controller.stream,
+        initialState: const ImportExportInitial(),
+      );
+      when(
+        () => mockGoRouter.push(any(), extra: any(named: 'extra')),
+      ).thenAnswer((_) async => null);
 
-        await loadSettingsScreen(tester);
+      await loadSettingsScreen(tester);
 
-        controller.add(
-          DuplicatesDetected(duplicates: [mockDuplicate], successfulImports: 0),
-        );
-        await tester.pumpAndSettle();
+      controller.add(
+        DuplicatesDetected(duplicates: [mockDuplicate], successfulImports: 0),
+      );
+      await tester.pumpAndSettle();
 
-        verify(
-          () => mockGoRouter.push(
-            AppRoutes.resolveDuplicates,
-            extra: any(named: 'extra'),
-          ),
-        ).called(1);
-        verify(
-          () => mockImportExportBloc.add(const ResetMigrationStatus()),
-        ).called(1);
-      },
-    );
+      verify(
+        () => mockGoRouter.push(
+          AppRoutes.resolveDuplicates,
+          extra: any(named: 'extra'),
+        ),
+      ).called(1);
+    });
 
     testWidgets('Shows success message on ClearDatabaseSuccess', (
       tester,

--- a/test/features/settings/presentation/screens/strategy_editor_test.dart
+++ b/test/features/settings/presentation/screens/strategy_editor_test.dart
@@ -1,5 +1,7 @@
+import 'package:animations/animations.dart';
 import 'package:bloc_test/bloc_test.dart';
 import 'package:get_it/get_it.dart';
+import 'package:passvault/features/password_manager/domain/entities/password_feedback.dart';
 import 'package:passvault/features/settings/domain/entities/password_generation_settings.dart';
 import 'package:passvault/features/settings/presentation/bloc/strategy_preview/strategy_preview_bloc.dart';
 import 'package:passvault/features/settings/presentation/screens/strategy_editor.dart';
@@ -53,17 +55,19 @@ void main() {
 
     await tester.pumpApp(
       Scaffold(
-        body: StatefulBuilder(
-          builder: (context, setState) {
-            return StrategyEditor(
-              strategy: strategy,
-              onChanged: (newStrategy) {
-                setState(() {
-                  strategy = newStrategy;
-                });
-              },
-            );
-          },
+        body: SingleChildScrollView(
+          child: StatefulBuilder(
+            builder: (context, setState) {
+              return StrategyEditor(
+                strategy: strategy,
+                onChanged: (newStrategy) {
+                  setState(() {
+                    strategy = newStrategy;
+                  });
+                },
+              );
+            },
+          ),
         ),
       ),
     );
@@ -151,4 +155,35 @@ void main() {
       ).called(1);
     },
   );
+
+  testWidgets('uses shared-axis transition container for strategy controls', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1200, 2400);
+    tester.view.devicePixelRatio = 3.0;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+
+    when(() => mockBloc.state).thenReturn(
+      const StrategyPreviewSuccess(
+        password: 'preview',
+        strength: PasswordFeedback.empty(),
+      ),
+    );
+    when(() => mockBloc.add(any())).thenReturn(null);
+
+    await tester.pumpApp(
+      SingleChildScrollView(
+        child: StrategyEditor(
+          strategy: PasswordGenerationStrategy.create(name: 'Initial'),
+          onChanged: (_) {},
+        ),
+      ),
+    );
+
+    expect(find.byType(PageTransitionSwitcher), findsWidgets);
+    expect(find.byType(SharedAxisTransition), findsWidgets);
+  });
 }

--- a/test/features/settings/presentation/settings_screen_helpers_test.dart
+++ b/test/features/settings/presentation/settings_screen_helpers_test.dart
@@ -1,0 +1,41 @@
+import 'package:passvault/features/settings/domain/entities/theme_type.dart';
+import 'package:passvault/features/settings/presentation/settings_screen_helpers.dart';
+
+import '../../../helpers/test_helpers.dart';
+
+void main() {
+  late AppLocalizations l10n;
+
+  setUpAll(() async {
+    l10n = await getL10n();
+  });
+
+  group('themeDisplayName', () {
+    test('returns system string for ThemeType.system', () {
+      expect(themeDisplayName(ThemeType.system, l10n), l10n.system);
+    });
+
+    test('returns light string for ThemeType.light', () {
+      expect(themeDisplayName(ThemeType.light, l10n), l10n.light);
+    });
+
+    test('returns dark string for ThemeType.dark', () {
+      expect(themeDisplayName(ThemeType.dark, l10n), l10n.dark);
+    });
+
+    test('returns amoled string for ThemeType.amoled', () {
+      expect(themeDisplayName(ThemeType.amoled, l10n), l10n.amoled);
+    });
+  });
+
+  group('localeDisplayName', () {
+    test('returns english string for en locale', () {
+      expect(localeDisplayName(const Locale('en'), l10n), l10n.english);
+    });
+
+    test('returns language tag for unsupported locale', () {
+      const locale = Locale('fr');
+      expect(localeDisplayName(locale, l10n), locale.toLanguageTag());
+    });
+  });
+}

--- a/test/features/shell/presentation/main_shell_test.dart
+++ b/test/features/shell/presentation/main_shell_test.dart
@@ -20,6 +20,11 @@ class MockThemeBloc extends MockBloc<ThemeEvent, ThemeState>
 
 void main() {
   late MockThemeBloc mockThemeBloc;
+  late AppLocalizations l10n;
+
+  setUpAll(() async {
+    l10n = await AppLocalizations.delegate.load(const Locale('en'));
+  });
 
   setUp(() {
     mockThemeBloc = MockThemeBloc();
@@ -45,7 +50,7 @@ void main() {
               routes: [
                 GoRoute(
                   path: '/a',
-                  builder: (context, state) => const Text('Vault'),
+                  builder: (context, state) => Text(l10n.vault),
                 ),
               ],
             ),
@@ -53,7 +58,7 @@ void main() {
               routes: [
                 GoRoute(
                   path: '/b',
-                  builder: (context, state) => const Text('Generator'),
+                  builder: (context, state) => Text(l10n.generator),
                 ),
               ],
             ),
@@ -61,7 +66,7 @@ void main() {
               routes: [
                 GoRoute(
                   path: '/c',
-                  builder: (context, state) => const Text('Settings'),
+                  builder: (context, state) => Text(l10n.settings),
                 ),
               ],
             ),
@@ -89,7 +94,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byType(Icon), findsNWidgets(3));
-      expect(find.text('Vault'), findsOneWidget);
+      expect(find.text(l10n.vault), findsOneWidget);
     });
 
     testWidgets('switches tabs on tap', (tester) async {
@@ -100,13 +105,13 @@ void main() {
       await tester.tap(find.byType(Icon).at(1));
       await tester.pumpAndSettle();
 
-      expect(find.text('Generator'), findsOneWidget);
+      expect(find.text(l10n.generator), findsOneWidget);
 
       // Tap Settings tab
       await tester.tap(find.byType(Icon).at(2));
       await tester.pumpAndSettle();
 
-      expect(find.text('Settings'), findsOneWidget);
+      expect(find.text(l10n.settings), findsOneWidget);
     });
 
     testWidgets('dynamic decoration matches AMOLED theme', (tester) async {


### PR DESCRIPTION
## Overview

Introduces a `PasswordEngineService` abstraction layer, migrates `password_engine` to pub.dev, refactors the generator UI with animations and a shared layout shell, and cleans up theme tokens throughout.

---

## Changes

### Dependencies
- Switch `password_engine` from a git path to the official pub.dev package
- Add `flutter_animate` and `animations` for UI motion primitives

### Design System
- **New** `AppFeatureShell` — shared scrollable-layout component with optional FAB overlay; eliminates duplicated `Scaffold`/`CustomScrollView`/`PageHeader` boilerplate across generator, strategy, and settings screens
- **New** `AppColors.white`, `AppColors.black`, `AppColors.transparent` tokens; replace all direct `Colors.black`, `Colors.white`, `Colors.transparent` references across all theme presets (`amoled`, `dark`, `light`) and `AppTheme`

### Password Engine — Domain & Service Layer
- **New** `PasswordEngineService` abstract interface
- **New** `PasswordEngineServiceImpl` — wraps the pub.dev package; registered via DI
- **New** `PasswordFeedback` entity with `strength`, `score`, `entropy`, `warning`, and `suggestions` fields
- Refactor `EstimatePasswordStrengthUsecase` and `GeneratePasswordUsecase` to depend on `PasswordEngineService` instead of the package directly

### Generator Feature
- Convert `GeneratorScreen` to `StatefulWidget`; track refresh tick for animated FAB icon
- Animated FAB — rotating refresh icon using `flutter_animate`
- Animated password display — `PageTransitionSwitcher` + `SharedAxisTransition` (vertical) + fade/slide/shimmer on password text change
- **New** `PasswordFeedbackView` — displays warning and up to 3 suggestions from `PasswordFeedback`
- **New** `PasswordGenerationControlsCard` — extracted to its own file, now handles both random and memorable strategies (word count + separator controls)
- **New** `LengthStepperButton` + `GeneratorToggleTile` extracted to `generator_control_widgets.dart`
- New `GeneratorBloc` events: `GeneratorWordCountChanged`, `GeneratorSeparatorChanged`

### Settings Feature
- `strategy_screen`, `strategy_editor_screen`, and `strategy_editor` migrated to use `AppFeatureShell`
- **New** `settings_screen_helpers.dart` — extracts helper action methods out of `settings_screen.dart`
- `StrategyPreviewCard` updated to reflect new `PasswordFeedback` entity shape
- `StrategyPreviewBloc`/`StrategyPreviewState` updated to use `PasswordFeedback`

### Add/Edit Password
- **New** `AddEditPasswordErrorCodes` class
- `AddEditPasswordBloc` and `AddEditPasswordState` updated for new service layer contracts

### Localisation
- New strings: `wordCountLabel`, `separatorLabel`, `separatorNone`, `memorableStrategy`, `randomStrategy`, `randomStrategyTitle`, `randomStrategySubtitle`, `memorableStrategyTitle`, `memorableStrategySubtitle`, `strategyTypeSubtitle`

### Tests
- **New** `generator_control_widgets_test.dart`
- **New** `password_engine_service_impl_test.dart`
- **New** `settings_screen_helpers_test.dart`
- **New** `import_export_bloc_actions_and_props_test.dart` (split from `import_export_bloc_test.dart`)
- **New** `add_edit_password_error_codes_test.dart`
- Updated: `generator_bloc_test`, `generator_screen_test`, `estimate_password_strength_usecase_test`, `generate_password_usecase_test`, `add_edit_password_bloc_test`, `strategy_preview_bloc_test`, `settings_screen_test`, `strategy_editor_test`
- All 400 tests pass

---

## Stats
`36 files changed · +1834 insertions · -737 deletions`

<!-- COVERAGE_START -->
## 📊 Code Coverage Report
| Metric | Value |
| :--- | :--- |
| **Total Lines** | 4901 |
| **Lines Hit** | 3960 |
| **Overall Coverage** | **80.80%** |

_Generated by PassVault CI_
<!-- COVERAGE_END -->
