### PR TITLE
feat: Refactor password domain grouping logic

### DIFF
--- a/lib/config/routes/app_router.dart
+++ b/lib/config/routes/app_router.dart
@@ -4,6 +4,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:injectable/injectable.dart';
 import 'package:passvault/config/routes/app_routes.dart';
+import 'package:passvault/config/routes/router_transitions.dart';
 import 'package:passvault/core/design_system/components/error/app_error_page.dart';
 import 'package:passvault/core/di/injection.dart';
 import 'package:passvault/core/observers/go_router_observer.dart';
@@ -13,6 +14,7 @@ import 'package:passvault/features/generator/presentation/bloc/generator/generat
 import 'package:passvault/features/generator/presentation/generator_screen.dart';
 import 'package:passvault/features/home/presentation/bloc/password/password_bloc.dart';
 import 'package:passvault/features/home/presentation/home_screen.dart';
+import 'package:passvault/features/home/presentation/screens/grouped_password_details_screen.dart';
 import 'package:passvault/features/onboarding/presentation/bloc/onboarding/onboarding_bloc.dart';
 import 'package:passvault/features/onboarding/presentation/intro_screen.dart';
 import 'package:passvault/features/password_manager/domain/entities/password_entry.dart';
@@ -86,7 +88,7 @@ class AppRouter {
           GoRoute(
             path: AppRoutes.intro,
             pageBuilder: (context, state) =>
-                _slideTransition(const IntroScreen(), state),
+                buildSlideTransition(const IntroScreen(), state),
           ),
         ],
       ),
@@ -122,7 +124,7 @@ class AppRouter {
                       GoRoute(
                         path: AppRoutes.addPasswordRoute,
                         parentNavigatorKey: _rootNavigatorKey,
-                        pageBuilder: (context, state) => _slideTransition(
+                        pageBuilder: (context, state) => buildSlideTransition(
                           const AddEditPasswordScreen(),
                           state,
                         ),
@@ -130,12 +132,27 @@ class AppRouter {
                       GoRoute(
                         path: AppRoutes.editPasswordRoute,
                         parentNavigatorKey: _rootNavigatorKey,
-                        pageBuilder: (context, state) => _slideTransition(
+                        pageBuilder: (context, state) => buildSlideTransition(
                           AddEditPasswordScreen(
                             id: (state.extra as PasswordEntry?)?.id,
                           ),
                           state,
                         ),
+                      ),
+                      GoRoute(
+                        path: AppRoutes.groupedPasswordDetailsSubRoute,
+                        parentNavigatorKey: _rootNavigatorKey,
+                        pageBuilder: (context, state) {
+                          final groupKey = Uri.decodeComponent(
+                            state.pathParameters[AppRoutes
+                                    .groupedPasswordKeyParam] ??
+                                '',
+                          );
+                          return buildSlideTransition(
+                            GroupedPasswordDetailsScreen(groupKey: groupKey),
+                            state,
+                          );
+                        },
                       ),
                     ],
                   ),
@@ -205,7 +222,7 @@ class AppRouter {
       GoRoute(
         path: AppRoutes.exportVault,
         parentNavigatorKey: _rootNavigatorKey,
-        pageBuilder: (context, state) => _slideTransition(
+        pageBuilder: (context, state) => buildSlideTransition(
           BlocProvider.value(
             value: getIt<ImportExportBloc>(),
             child: const ExportVaultScreen(),
@@ -216,7 +233,7 @@ class AppRouter {
       GoRoute(
         path: AppRoutes.strategy,
         parentNavigatorKey: _rootNavigatorKey,
-        pageBuilder: (context, state) => _slideTransition(
+        pageBuilder: (context, state) => buildSlideTransition(
           BlocProvider.value(
             value: getIt<SettingsBloc>(),
             child: const StrategyScreen(),
@@ -230,7 +247,7 @@ class AppRouter {
             pageBuilder: (context, state) {
               final strategyId =
                   (state.extra as Map<String, String>)['strategyId'];
-              return _slideTransition(
+              return buildSlideTransition(
                 BlocProvider.value(
                   value: getIt<SettingsBloc>(),
                   child: StrategyEditorScreen(strategyId: strategyId),
@@ -243,53 +260,4 @@ class AppRouter {
       ),
     ],
   );
-
-  CustomTransitionPage<void> _slideTransition(
-    Widget child,
-    GoRouterState state,
-  ) {
-    return CustomTransitionPage<void>(
-      key: state.pageKey,
-      child: child,
-      transitionDuration: const Duration(milliseconds: 300),
-      reverseTransitionDuration: const Duration(milliseconds: 300),
-      transitionsBuilder: (context, animation, secondaryAnimation, child) {
-        const curve = Curves.easeInOut;
-
-        final slideIn = Tween<Offset>(
-          begin: const Offset(1.0, 0.0),
-          end: Offset.zero,
-        ).chain(CurveTween(curve: curve));
-
-        final fadeIn = Tween<double>(
-          begin: 0.0,
-          end: 1.0,
-        ).chain(CurveTween(curve: curve));
-
-        final slideOut = Tween<Offset>(
-          begin: Offset.zero,
-          end: const Offset(-0.25, 0.0),
-        ).chain(CurveTween(curve: curve));
-
-        final fadeOut = Tween<double>(
-          begin: 1.0,
-          end: 0.85,
-        ).chain(CurveTween(curve: curve));
-
-        return SlideTransition(
-          position: secondaryAnimation.drive(slideOut),
-          child: FadeTransition(
-            opacity: secondaryAnimation.drive(fadeOut),
-            child: SlideTransition(
-              position: animation.drive(slideIn),
-              child: FadeTransition(
-                opacity: animation.drive(fadeIn),
-                child: child,
-              ),
-            ),
-          ),
-        );
-      },
-    );
-  }
 }

--- a/lib/config/routes/app_router.dart
+++ b/lib/config/routes/app_router.dart
@@ -141,7 +141,6 @@ class AppRouter {
                       ),
                       GoRoute(
                         path: AppRoutes.groupedPasswordDetailsSubRoute,
-                        parentNavigatorKey: _rootNavigatorKey,
                         pageBuilder: (context, state) {
                           final groupKey = Uri.decodeComponent(
                             state.pathParameters[AppRoutes

--- a/lib/config/routes/app_routes.dart
+++ b/lib/config/routes/app_routes.dart
@@ -12,6 +12,10 @@ abstract class AppRoutes {
   // Sub-routes (Relative Paths)
   static const String addPasswordRoute = 'add-password';
   static const String editPasswordRoute = 'edit-password';
+  static const String groupedPasswordDetailsRoute = 'group';
+  static const String groupedPasswordKeyParam = 'groupKey';
+  static const String groupedPasswordDetailsSubRoute =
+      '$groupedPasswordDetailsRoute/:$groupedPasswordKeyParam';
   static const String exportVaultRoute = 'export';
   static const String strategyRoute = 'strategy';
   static const String strategyEditorRoute = 'strategy-editor';
@@ -19,6 +23,8 @@ abstract class AppRoutes {
   // Full Paths (for Navigation)
   static const String addPassword = '$home/$addPasswordRoute';
   static const String editPassword = '$home/$editPasswordRoute';
+  static String groupedPasswordDetailsPath(String groupKey) =>
+      '$home/$groupedPasswordDetailsRoute/${Uri.encodeComponent(groupKey)}';
   static const String exportVault = '$settings/$exportVaultRoute';
   static const String strategy = '$settings/$strategyRoute';
   static const String strategyEditor =

--- a/lib/config/routes/router_transitions.dart
+++ b/lib/config/routes/router_transitions.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+CustomTransitionPage<void> buildSlideTransition(
+  Widget child,
+  GoRouterState state,
+) {
+  return CustomTransitionPage<void>(
+    key: state.pageKey,
+    child: child,
+    transitionDuration: const Duration(milliseconds: 300),
+    reverseTransitionDuration: const Duration(milliseconds: 300),
+    transitionsBuilder: (context, animation, secondaryAnimation, child) {
+      const curve = Curves.easeInOut;
+
+      final slideIn = Tween<Offset>(
+        begin: const Offset(1.0, 0.0),
+        end: Offset.zero,
+      ).chain(CurveTween(curve: curve));
+
+      final fadeIn = Tween<double>(
+        begin: 0.0,
+        end: 1.0,
+      ).chain(CurveTween(curve: curve));
+
+      final slideOut = Tween<Offset>(
+        begin: Offset.zero,
+        end: const Offset(-0.25, 0.0),
+      ).chain(CurveTween(curve: curve));
+
+      final fadeOut = Tween<double>(
+        begin: 1.0,
+        end: 0.85,
+      ).chain(CurveTween(curve: curve));
+
+      return SlideTransition(
+        position: secondaryAnimation.drive(slideOut),
+        child: FadeTransition(
+          opacity: secondaryAnimation.drive(fadeOut),
+          child: SlideTransition(
+            position: animation.drive(slideIn),
+            child: FadeTransition(
+              opacity: animation.drive(fadeIn),
+              child: child,
+            ),
+          ),
+        ),
+      );
+    },
+  );
+}

--- a/lib/features/home/domain/entities/grouped_home_entry.dart
+++ b/lib/features/home/domain/entities/grouped_home_entry.dart
@@ -1,0 +1,19 @@
+import 'package:equatable/equatable.dart';
+import 'package:passvault/features/password_manager/domain/entities/password_entry.dart';
+
+class GroupedHomeEntry extends Equatable {
+  final String canonicalKey;
+  final String displayName;
+  final List<PasswordEntry> members;
+
+  const GroupedHomeEntry({
+    required this.canonicalKey,
+    required this.displayName,
+    required this.members,
+  });
+
+  int get accountCount => members.length;
+
+  @override
+  List<Object?> get props => [canonicalKey, displayName, members];
+}

--- a/lib/features/home/domain/services/credential_grouping_service.dart
+++ b/lib/features/home/domain/services/credential_grouping_service.dart
@@ -1,0 +1,99 @@
+import 'package:passvault/features/home/domain/entities/grouped_home_entry.dart';
+import 'package:passvault/features/password_manager/domain/entities/password_entry.dart';
+
+class CredentialGroupingService {
+  const CredentialGroupingService();
+
+  List<GroupedHomeEntry> group(List<PasswordEntry> credentials) {
+    final groupedByCanonicalKey = <String, List<PasswordEntry>>{};
+    final displayByCanonicalKey = <String, String>{};
+
+    for (final credential in credentials) {
+      final canonicalKey = _canonicalKeyFor(credential);
+      groupedByCanonicalKey.putIfAbsent(canonicalKey, () => []).add(credential);
+      displayByCanonicalKey.putIfAbsent(
+        canonicalKey,
+        () => _displayNameFor(credential, canonicalKey),
+      );
+    }
+
+    final groupedEntries = groupedByCanonicalKey.entries.map((group) {
+      final sortedMembers = [...group.value]..sort(_compareMemberEntries);
+      return GroupedHomeEntry(
+        canonicalKey: group.key,
+        displayName: displayByCanonicalKey[group.key] ?? group.key,
+        members: sortedMembers,
+      );
+    }).toList();
+
+    groupedEntries.sort(_compareGroupedEntries);
+    return groupedEntries;
+  }
+
+  String canonicalizeTarget(String target) {
+    final trimmed = target.trim();
+    if (trimmed.isEmpty) {
+      return trimmed;
+    }
+
+    final lowercased = trimmed.toLowerCase();
+    final withoutScheme = lowercased.replaceFirst(RegExp(r'^https?://'), '');
+    final withoutLeadingWww = withoutScheme.replaceFirst(RegExp(r'^www\.'), '');
+    return withoutLeadingWww;
+  }
+
+  String _canonicalKeyFor(PasswordEntry entry) {
+    final normalizedUrl = canonicalizeTarget(entry.url ?? '');
+    if (normalizedUrl.isNotEmpty) {
+      return normalizedUrl;
+    }
+
+    final normalizedAppName = canonicalizeTarget(entry.appName);
+    if (normalizedAppName.isNotEmpty) {
+      return normalizedAppName;
+    }
+
+    return entry.id;
+  }
+
+  String _displayNameFor(PasswordEntry entry, String fallbackCanonical) {
+    final normalizedUrl = canonicalizeTarget(entry.url ?? '');
+    if (normalizedUrl.isNotEmpty) {
+      return normalizedUrl;
+    }
+
+    final appName = entry.appName.trim();
+    if (appName.isNotEmpty) {
+      return appName;
+    }
+
+    return fallbackCanonical;
+  }
+
+  int _compareGroupedEntries(GroupedHomeEntry left, GroupedHomeEntry right) {
+    final byDisplay = left.displayName.toLowerCase().compareTo(
+      right.displayName.toLowerCase(),
+    );
+    if (byDisplay != 0) {
+      return byDisplay;
+    }
+
+    return left.canonicalKey.compareTo(right.canonicalKey);
+  }
+
+  int _compareMemberEntries(PasswordEntry left, PasswordEntry right) {
+    final byUsername = left.username.toLowerCase().compareTo(
+      right.username.toLowerCase(),
+    );
+    if (byUsername != 0) {
+      return byUsername;
+    }
+
+    final byUpdated = right.lastUpdated.compareTo(left.lastUpdated);
+    if (byUpdated != 0) {
+      return byUpdated;
+    }
+
+    return left.id.compareTo(right.id);
+  }
+}

--- a/lib/features/home/domain/services/credential_grouping_service.dart
+++ b/lib/features/home/domain/services/credential_grouping_service.dart
@@ -3,17 +3,30 @@ import 'package:passvault/features/password_manager/domain/entities/password_ent
 
 class CredentialGroupingService {
   const CredentialGroupingService();
+  static const Set<String> _subdomainCollapsePrefixes = {
+    'www',
+    'm',
+    'mobile',
+    'accounts',
+    'account',
+    'auth',
+    'login',
+    'signin',
+    'id',
+    'app',
+  };
 
   List<GroupedHomeEntry> group(List<PasswordEntry> credentials) {
     final groupedByCanonicalKey = <String, List<PasswordEntry>>{};
     final displayByCanonicalKey = <String, String>{};
 
     for (final credential in credentials) {
-      final canonicalKey = _canonicalKeyFor(credential);
+      final identity = _targetIdentityFor(credential);
+      final canonicalKey = identity.canonicalKey;
       groupedByCanonicalKey.putIfAbsent(canonicalKey, () => []).add(credential);
       displayByCanonicalKey.putIfAbsent(
         canonicalKey,
-        () => _displayNameFor(credential, canonicalKey),
+        () => identity.displayName,
       );
     }
 
@@ -42,34 +55,6 @@ class CredentialGroupingService {
     return withoutLeadingWww;
   }
 
-  String _canonicalKeyFor(PasswordEntry entry) {
-    final normalizedUrl = canonicalizeTarget(entry.url ?? '');
-    if (normalizedUrl.isNotEmpty) {
-      return normalizedUrl;
-    }
-
-    final normalizedAppName = canonicalizeTarget(entry.appName);
-    if (normalizedAppName.isNotEmpty) {
-      return normalizedAppName;
-    }
-
-    return entry.id;
-  }
-
-  String _displayNameFor(PasswordEntry entry, String fallbackCanonical) {
-    final normalizedUrl = canonicalizeTarget(entry.url ?? '');
-    if (normalizedUrl.isNotEmpty) {
-      return normalizedUrl;
-    }
-
-    final appName = entry.appName.trim();
-    if (appName.isNotEmpty) {
-      return appName;
-    }
-
-    return fallbackCanonical;
-  }
-
   int _compareGroupedEntries(GroupedHomeEntry left, GroupedHomeEntry right) {
     final byDisplay = left.displayName.toLowerCase().compareTo(
       right.displayName.toLowerCase(),
@@ -96,4 +81,192 @@ class CredentialGroupingService {
 
     return left.id.compareTo(right.id);
   }
+
+  _TargetIdentity _targetIdentityFor(PasswordEntry entry) {
+    final rawTarget = (entry.url ?? '').trim().isNotEmpty
+        ? (entry.url ?? '').trim()
+        : entry.appName.trim();
+    final normalizedTarget = canonicalizeTarget(rawTarget);
+
+    final androidPackage =
+        _androidPackageFromRealm(normalizedTarget) ??
+        _androidPackageLike(normalizedTarget);
+    if (androidPackage != null && androidPackage.isNotEmpty) {
+      final storedName = entry.appName.trim();
+      return _TargetIdentity(
+        canonicalKey: 'android:$androidPackage',
+        displayName: storedName.isNotEmpty
+            ? storedName
+            : _prettifyPackageLabel(androidPackage),
+      );
+    }
+
+    final host = _hostFromTarget(normalizedTarget);
+    if (host != null && host.isNotEmpty) {
+      return _TargetIdentity(canonicalKey: host, displayName: host);
+    }
+
+    final appName = entry.appName.trim();
+    if (appName.isNotEmpty) {
+      return _TargetIdentity(
+        canonicalKey: canonicalizeTarget(appName),
+        displayName: appName,
+      );
+    }
+
+    return _TargetIdentity(canonicalKey: entry.id, displayName: entry.id);
+  }
+
+  String? _hostFromTarget(String normalizedTarget) {
+    if (normalizedTarget.isEmpty) {
+      return null;
+    }
+    if (normalizedTarget.contains(' ')) {
+      return null;
+    }
+    final hasScheme = normalizedTarget.contains('://');
+    final hasDomainHint = normalizedTarget.contains('.');
+    if (!hasScheme && !hasDomainHint) {
+      return null;
+    }
+
+    Uri? uri = Uri.tryParse(normalizedTarget);
+    if (uri == null || uri.host.isEmpty) {
+      uri = Uri.tryParse('https://$normalizedTarget');
+    }
+    if (uri == null || uri.host.isEmpty) {
+      return null;
+    }
+
+    final normalizedHost = uri.host.toLowerCase().replaceFirst(
+      RegExp(r'^www\.'),
+      '',
+    );
+    return _canonicalWebHost(normalizedHost);
+  }
+
+  String _canonicalWebHost(String host) {
+    final labels = host.split('.');
+    if (labels.length <= 2) {
+      return host;
+    }
+
+    final prefix = labels.first;
+    if (_shouldCollapseSubdomain(prefix)) {
+      return _registrableDomain(host);
+    }
+
+    return host;
+  }
+
+  bool _shouldCollapseSubdomain(String prefix) {
+    if (_subdomainCollapsePrefixes.contains(prefix)) {
+      return true;
+    }
+
+    // Handles common noisy prefixes like ww2.example.com or wwe.example.com.
+    return RegExp(r'^ww[a-z0-9]*$').hasMatch(prefix);
+  }
+
+  String _registrableDomain(String host) {
+    final labels = host.split('.');
+    if (labels.length <= 2) {
+      return host;
+    }
+
+    final last = labels[labels.length - 1];
+    final secondLast = labels[labels.length - 2];
+    final thirdLast = labels[labels.length - 3];
+    final ccTldLike = {'uk', 'jp', 'au', 'nz', 'za', 'in', 'br'};
+    final secondLevelSet = {'co', 'com', 'org', 'net', 'gov', 'ac', 'edu'};
+
+    if (ccTldLike.contains(last) && secondLevelSet.contains(secondLast)) {
+      return '$thirdLast.$secondLast.$last';
+    }
+
+    return '$secondLast.$last';
+  }
+
+  String? _androidPackageFromRealm(String normalizedTarget) {
+    final match = RegExp(
+      r'^android://[^@/]+@([^/]+)/?$',
+      caseSensitive: false,
+    ).firstMatch(normalizedTarget);
+    return match?.group(1)?.trim().toLowerCase();
+  }
+
+  String? _androidPackageLike(String normalizedTarget) {
+    if (normalizedTarget.startsWith('android:')) {
+      return normalizedTarget.replaceFirst('android:', '').trim();
+    }
+    final packageRegex = RegExp(r'^[a-z0-9_]+(\.[a-z0-9_]+){2,}$');
+    if (!packageRegex.hasMatch(normalizedTarget)) {
+      return null;
+    }
+
+    final labels = normalizedTarget.split('.');
+    if (labels.length < 3) {
+      return null;
+    }
+    final knownTlds = {
+      'com',
+      'org',
+      'net',
+      'in',
+      'co',
+      'io',
+      'dev',
+      'app',
+      'uk',
+      'au',
+      'jp',
+      'br',
+      'de',
+      'fr',
+      'us',
+      'ca',
+      'nl',
+      'es',
+      'it',
+      'ru',
+      'xyz',
+    };
+    if (knownTlds.contains(labels.last)) {
+      return null;
+    }
+
+    return normalizedTarget;
+  }
+
+  String _prettifyPackageLabel(String packageName) {
+    final segments = packageName
+        .split('.')
+        .where((segment) => segment.isNotEmpty);
+    final filteredSegments = segments
+        .where(
+          (segment) => segment != 'com' && segment != 'org' && segment != 'net',
+        )
+        .toList();
+    final candidate = filteredSegments.isEmpty
+        ? packageName
+        : filteredSegments.first;
+    final sanitized = candidate
+        .replaceAll(RegExp(r'[_-]+'), ' ')
+        .replaceAll(RegExp(r'android', caseSensitive: false), '')
+        .trim();
+    if (sanitized.isEmpty) {
+      return packageName;
+    }
+    return sanitized[0].toUpperCase() + sanitized.substring(1);
+  }
+}
+
+class _TargetIdentity {
+  final String canonicalKey;
+  final String displayName;
+
+  const _TargetIdentity({
+    required this.canonicalKey,
+    required this.displayName,
+  });
 }

--- a/lib/features/home/domain/services/credential_grouping_service.dart
+++ b/lib/features/home/domain/services/credential_grouping_service.dart
@@ -1,40 +1,25 @@
 import 'package:passvault/features/home/domain/entities/grouped_home_entry.dart';
+import 'package:passvault/features/home/domain/services/credential_target_parser.dart';
 import 'package:passvault/features/password_manager/domain/entities/password_entry.dart';
 
 class CredentialGroupingService {
   const CredentialGroupingService();
-  static const Set<String> _subdomainCollapsePrefixes = {
-    'www',
-    'm',
-    'mobile',
-    'accounts',
-    'account',
-    'auth',
-    'login',
-    'signin',
-    'id',
-    'app',
-  };
+
+  static const CredentialTargetParser _targetParser = CredentialTargetParser();
 
   List<GroupedHomeEntry> group(List<PasswordEntry> credentials) {
     final groupedByCanonicalKey = <String, List<PasswordEntry>>{};
-    final displayByCanonicalKey = <String, String>{};
 
     for (final credential in credentials) {
-      final identity = _targetIdentityFor(credential);
-      final canonicalKey = identity.canonicalKey;
+      final canonicalKey = _targetIdentityFor(credential).canonicalKey;
       groupedByCanonicalKey.putIfAbsent(canonicalKey, () => []).add(credential);
-      displayByCanonicalKey.putIfAbsent(
-        canonicalKey,
-        () => identity.displayName,
-      );
     }
 
     final groupedEntries = groupedByCanonicalKey.entries.map((group) {
       final sortedMembers = [...group.value]..sort(_compareMemberEntries);
       return GroupedHomeEntry(
         canonicalKey: group.key,
-        displayName: displayByCanonicalKey[group.key] ?? group.key,
+        displayName: _displayNameForGroup(group.key, sortedMembers),
         members: sortedMembers,
       );
     }).toList();
@@ -43,16 +28,78 @@ class CredentialGroupingService {
     return groupedEntries;
   }
 
-  String canonicalizeTarget(String target) {
-    final trimmed = target.trim();
-    if (trimmed.isEmpty) {
-      return trimmed;
+  String canonicalizeTarget(String target) =>
+      _targetParser.canonicalizeTarget(target);
+
+  String _displayNameForGroup(
+    String canonicalKey,
+    List<PasswordEntry> members,
+  ) {
+    final storedAppName = _bestStoredAppName(members);
+    if (storedAppName != null) {
+      return storedAppName;
     }
 
-    final lowercased = trimmed.toLowerCase();
-    final withoutScheme = lowercased.replaceFirst(RegExp(r'^https?://'), '');
-    final withoutLeadingWww = withoutScheme.replaceFirst(RegExp(r'^www\.'), '');
-    return withoutLeadingWww;
+    if (canonicalKey.startsWith('android:')) {
+      final packageName = canonicalKey.replaceFirst('android:', '');
+      if (packageName.isNotEmpty) {
+        return _targetParser.prettifyPackageLabel(packageName);
+      }
+    }
+
+    return canonicalKey;
+  }
+
+  String? _bestStoredAppName(List<PasswordEntry> members) {
+    final statsByName = <String, _NameStats>{};
+
+    for (final member in members) {
+      final appName = member.appName.trim();
+      if (appName.isEmpty) {
+        continue;
+      }
+
+      final key = appName.toLowerCase();
+      final existing = statsByName[key];
+      if (existing == null) {
+        statsByName[key] = _NameStats(
+          displayName: appName,
+          count: 1,
+          lastUpdated: member.lastUpdated,
+        );
+        continue;
+      }
+
+      final shouldReplaceDisplay = member.lastUpdated.isAfter(
+        existing.lastUpdated,
+      );
+      statsByName[key] = _NameStats(
+        displayName: shouldReplaceDisplay ? appName : existing.displayName,
+        count: existing.count + 1,
+        lastUpdated: shouldReplaceDisplay
+            ? member.lastUpdated
+            : existing.lastUpdated,
+      );
+    }
+
+    if (statsByName.isEmpty) {
+      return null;
+    }
+
+    final candidates = statsByName.entries.toList()
+      ..sort((left, right) {
+        final byCount = right.value.count.compareTo(left.value.count);
+        if (byCount != 0) return byCount;
+
+        final byUpdated = right.value.lastUpdated.compareTo(
+          left.value.lastUpdated,
+        );
+        if (byUpdated != 0) return byUpdated;
+
+        return left.key.compareTo(right.key);
+      });
+
+    return candidates.first.value.displayName;
   }
 
   int _compareGroupedEntries(GroupedHomeEntry left, GroupedHomeEntry right) {
@@ -89,184 +136,40 @@ class CredentialGroupingService {
     final normalizedTarget = canonicalizeTarget(rawTarget);
 
     final androidPackage =
-        _androidPackageFromRealm(normalizedTarget) ??
-        _androidPackageLike(normalizedTarget);
+        _targetParser.androidPackageFromRealm(normalizedTarget) ??
+        _targetParser.androidPackageLike(normalizedTarget);
     if (androidPackage != null && androidPackage.isNotEmpty) {
-      final storedName = entry.appName.trim();
-      return _TargetIdentity(
-        canonicalKey: 'android:$androidPackage',
-        displayName: storedName.isNotEmpty
-            ? storedName
-            : _prettifyPackageLabel(androidPackage),
-      );
+      return _TargetIdentity(canonicalKey: 'android:$androidPackage');
     }
 
-    final host = _hostFromTarget(normalizedTarget);
+    final host = _targetParser.hostFromTarget(normalizedTarget);
     if (host != null && host.isNotEmpty) {
-      return _TargetIdentity(canonicalKey: host, displayName: host);
+      return _TargetIdentity(canonicalKey: host);
     }
 
     final appName = entry.appName.trim();
     if (appName.isNotEmpty) {
-      return _TargetIdentity(
-        canonicalKey: canonicalizeTarget(appName),
-        displayName: appName,
-      );
+      return _TargetIdentity(canonicalKey: canonicalizeTarget(appName));
     }
 
-    return _TargetIdentity(canonicalKey: entry.id, displayName: entry.id);
-  }
-
-  String? _hostFromTarget(String normalizedTarget) {
-    if (normalizedTarget.isEmpty) {
-      return null;
-    }
-    if (normalizedTarget.contains(' ')) {
-      return null;
-    }
-    final hasScheme = normalizedTarget.contains('://');
-    final hasDomainHint = normalizedTarget.contains('.');
-    if (!hasScheme && !hasDomainHint) {
-      return null;
-    }
-
-    Uri? uri = Uri.tryParse(normalizedTarget);
-    if (uri == null || uri.host.isEmpty) {
-      uri = Uri.tryParse('https://$normalizedTarget');
-    }
-    if (uri == null || uri.host.isEmpty) {
-      return null;
-    }
-
-    final normalizedHost = uri.host.toLowerCase().replaceFirst(
-      RegExp(r'^www\.'),
-      '',
-    );
-    return _canonicalWebHost(normalizedHost);
-  }
-
-  String _canonicalWebHost(String host) {
-    final labels = host.split('.');
-    if (labels.length <= 2) {
-      return host;
-    }
-
-    final prefix = labels.first;
-    if (_shouldCollapseSubdomain(prefix)) {
-      return _registrableDomain(host);
-    }
-
-    return host;
-  }
-
-  bool _shouldCollapseSubdomain(String prefix) {
-    if (_subdomainCollapsePrefixes.contains(prefix)) {
-      return true;
-    }
-
-    // Handles common noisy prefixes like ww2.example.com or wwe.example.com.
-    return RegExp(r'^ww[a-z0-9]*$').hasMatch(prefix);
-  }
-
-  String _registrableDomain(String host) {
-    final labels = host.split('.');
-    if (labels.length <= 2) {
-      return host;
-    }
-
-    final last = labels[labels.length - 1];
-    final secondLast = labels[labels.length - 2];
-    final thirdLast = labels[labels.length - 3];
-    final ccTldLike = {'uk', 'jp', 'au', 'nz', 'za', 'in', 'br'};
-    final secondLevelSet = {'co', 'com', 'org', 'net', 'gov', 'ac', 'edu'};
-
-    if (ccTldLike.contains(last) && secondLevelSet.contains(secondLast)) {
-      return '$thirdLast.$secondLast.$last';
-    }
-
-    return '$secondLast.$last';
-  }
-
-  String? _androidPackageFromRealm(String normalizedTarget) {
-    final match = RegExp(
-      r'^android://[^@/]+@([^/]+)/?$',
-      caseSensitive: false,
-    ).firstMatch(normalizedTarget);
-    return match?.group(1)?.trim().toLowerCase();
-  }
-
-  String? _androidPackageLike(String normalizedTarget) {
-    if (normalizedTarget.startsWith('android:')) {
-      return normalizedTarget.replaceFirst('android:', '').trim();
-    }
-    final packageRegex = RegExp(r'^[a-z0-9_]+(\.[a-z0-9_]+){2,}$');
-    if (!packageRegex.hasMatch(normalizedTarget)) {
-      return null;
-    }
-
-    final labels = normalizedTarget.split('.');
-    if (labels.length < 3) {
-      return null;
-    }
-    final knownTlds = {
-      'com',
-      'org',
-      'net',
-      'in',
-      'co',
-      'io',
-      'dev',
-      'app',
-      'uk',
-      'au',
-      'jp',
-      'br',
-      'de',
-      'fr',
-      'us',
-      'ca',
-      'nl',
-      'es',
-      'it',
-      'ru',
-      'xyz',
-    };
-    if (knownTlds.contains(labels.last)) {
-      return null;
-    }
-
-    return normalizedTarget;
-  }
-
-  String _prettifyPackageLabel(String packageName) {
-    final segments = packageName
-        .split('.')
-        .where((segment) => segment.isNotEmpty);
-    final filteredSegments = segments
-        .where(
-          (segment) => segment != 'com' && segment != 'org' && segment != 'net',
-        )
-        .toList();
-    final candidate = filteredSegments.isEmpty
-        ? packageName
-        : filteredSegments.first;
-    final sanitized = candidate
-        .replaceAll(RegExp(r'[_-]+'), ' ')
-        .replaceAll(RegExp(r'android', caseSensitive: false), '')
-        .trim();
-    if (sanitized.isEmpty) {
-      return packageName;
-    }
-    return sanitized[0].toUpperCase() + sanitized.substring(1);
+    return _TargetIdentity(canonicalKey: entry.id);
   }
 }
 
 class _TargetIdentity {
   final String canonicalKey;
-  final String displayName;
 
-  const _TargetIdentity({
-    required this.canonicalKey,
+  const _TargetIdentity({required this.canonicalKey});
+}
+
+class _NameStats {
+  final String displayName;
+  final int count;
+  final DateTime lastUpdated;
+
+  const _NameStats({
     required this.displayName,
+    required this.count,
+    required this.lastUpdated,
   });
 }

--- a/lib/features/home/domain/services/credential_target_parser.dart
+++ b/lib/features/home/domain/services/credential_target_parser.dart
@@ -1,0 +1,142 @@
+class CredentialTargetParser {
+  const CredentialTargetParser();
+
+  String canonicalizeTarget(String target) {
+    final trimmed = target.trim();
+    if (trimmed.isEmpty) {
+      return trimmed;
+    }
+
+    final lowercased = trimmed.toLowerCase();
+    final withoutScheme = lowercased.replaceFirst(RegExp(r'^https?://'), '');
+    final withoutLeadingWww = withoutScheme.replaceFirst(RegExp(r'^www\.'), '');
+    return withoutLeadingWww;
+  }
+
+  String? hostFromTarget(String normalizedTarget) {
+    if (normalizedTarget.isEmpty || normalizedTarget.contains(' ')) {
+      return null;
+    }
+
+    final hasScheme = normalizedTarget.contains('://');
+    final hasDomainHint = normalizedTarget.contains('.');
+    if (!hasScheme && !hasDomainHint) {
+      return null;
+    }
+
+    Uri? uri = Uri.tryParse(normalizedTarget);
+    if (uri == null || uri.host.isEmpty) {
+      uri = Uri.tryParse('https://$normalizedTarget');
+    }
+    if (uri == null || uri.host.isEmpty) {
+      return null;
+    }
+
+    final normalizedHost = uri.host.toLowerCase().replaceFirst(
+      RegExp(r'^www\.'),
+      '',
+    );
+    return _canonicalWebHost(normalizedHost);
+  }
+
+  String? androidPackageFromRealm(String normalizedTarget) {
+    final match = RegExp(
+      r'^android://[^@/]+@([^/]+)/?$',
+      caseSensitive: false,
+    ).firstMatch(normalizedTarget);
+    return match?.group(1)?.trim().toLowerCase();
+  }
+
+  String? androidPackageLike(String normalizedTarget) {
+    if (normalizedTarget.startsWith('android:')) {
+      return normalizedTarget.replaceFirst('android:', '').trim();
+    }
+
+    final packageRegex = RegExp(r'^[a-z0-9_]+(\.[a-z0-9_]+){2,}$');
+    if (!packageRegex.hasMatch(normalizedTarget)) {
+      return null;
+    }
+
+    final labels = normalizedTarget.split('.');
+    if (labels.length < 3) {
+      return null;
+    }
+
+    final knownTlds = {
+      'com',
+      'org',
+      'net',
+      'in',
+      'co',
+      'io',
+      'dev',
+      'app',
+      'uk',
+      'au',
+      'jp',
+      'br',
+      'de',
+      'fr',
+      'us',
+      'ca',
+      'nl',
+      'es',
+      'it',
+      'ru',
+      'xyz',
+    };
+    if (knownTlds.contains(labels.last)) {
+      return null;
+    }
+
+    return normalizedTarget;
+  }
+
+  String prettifyPackageLabel(String packageName) {
+    final segments = packageName
+        .split('.')
+        .where((segment) => segment.isNotEmpty);
+    final filteredSegments = segments
+        .where(
+          (segment) => segment != 'com' && segment != 'org' && segment != 'net',
+        )
+        .toList();
+
+    final candidate = filteredSegments.isEmpty
+        ? packageName
+        : filteredSegments.first;
+    final sanitized = candidate
+        .replaceAll(RegExp(r'[_-]+'), ' ')
+        .replaceAll(RegExp(r'android', caseSensitive: false), '')
+        .trim();
+
+    if (sanitized.isEmpty) {
+      return packageName;
+    }
+
+    return sanitized[0].toUpperCase() + sanitized.substring(1);
+  }
+
+  String _canonicalWebHost(String host) {
+    return _registrableDomain(host);
+  }
+
+  String _registrableDomain(String host) {
+    final labels = host.split('.');
+    if (labels.length <= 2) {
+      return host;
+    }
+
+    final last = labels[labels.length - 1];
+    final secondLast = labels[labels.length - 2];
+    final thirdLast = labels[labels.length - 3];
+    final ccTldLike = {'uk', 'jp', 'au', 'nz', 'za', 'in', 'br'};
+    final secondLevelSet = {'co', 'com', 'org', 'net', 'gov', 'ac', 'edu'};
+
+    if (ccTldLike.contains(last) && secondLevelSet.contains(secondLast)) {
+      return '$thirdLast.$secondLast.$last';
+    }
+
+    return '$secondLast.$last';
+  }
+}

--- a/lib/features/home/domain/usecases/get_grouped_home_entries_usecase.dart
+++ b/lib/features/home/domain/usecases/get_grouped_home_entries_usecase.dart
@@ -1,0 +1,42 @@
+import 'package:equatable/equatable.dart';
+import 'package:passvault/core/error/error.dart';
+import 'package:passvault/features/home/domain/entities/grouped_home_entry.dart';
+import 'package:passvault/features/home/domain/services/credential_grouping_service.dart';
+import 'package:passvault/features/password_manager/domain/entities/password_entry.dart';
+import 'package:passvault/features/password_manager/domain/usecases/password_usecases.dart';
+
+class GroupedHomeEntriesPayload extends Equatable {
+  final List<PasswordEntry> passwords;
+  final List<GroupedHomeEntry> groupedEntries;
+
+  const GroupedHomeEntriesPayload({
+    required this.passwords,
+    required this.groupedEntries,
+  });
+
+  @override
+  List<Object?> get props => [passwords, groupedEntries];
+}
+
+class GetGroupedHomeEntriesUseCase {
+  final GetPasswordsUseCase _getPasswordsUseCase;
+  final CredentialGroupingService _groupingService;
+
+  const GetGroupedHomeEntriesUseCase(
+    this._getPasswordsUseCase,
+    this._groupingService,
+  );
+
+  Future<Result<GroupedHomeEntriesPayload>> call() async {
+    final passwordsResult = await _getPasswordsUseCase();
+    return passwordsResult.fold(
+      Error.new,
+      (passwords) => Success(
+        GroupedHomeEntriesPayload(
+          passwords: passwords,
+          groupedEntries: _groupingService.group(passwords),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/home/presentation/bloc/password/password_bloc.dart
+++ b/lib/features/home/presentation/bloc/password/password_bloc.dart
@@ -4,6 +4,9 @@ import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:injectable/injectable.dart';
 import 'package:passvault/core/utils/app_logger.dart';
+import 'package:passvault/features/home/domain/entities/grouped_home_entry.dart';
+import 'package:passvault/features/home/domain/services/credential_grouping_service.dart';
+import 'package:passvault/features/home/domain/usecases/get_grouped_home_entries_usecase.dart';
 import 'package:passvault/features/password_manager/domain/entities/password_entry.dart';
 import 'package:passvault/features/password_manager/domain/repositories/password_repository.dart';
 import 'package:passvault/features/password_manager/domain/usecases/password_usecases.dart';
@@ -17,6 +20,11 @@ class PasswordBloc extends Bloc<PasswordEvent, PasswordState> {
   final SavePasswordUseCase _savePassword;
   final DeletePasswordUseCase _deletePassword;
   final PasswordRepository _repository;
+  late final CredentialGroupingService _groupingService;
+  late final GetGroupedHomeEntriesUseCase _getGroupedHomeEntries;
+  String _searchQuery = '';
+  String? _folderFilter;
+  bool _favoritesOnly = false;
 
   // Stream subscription for external data changes
   StreamSubscription<void>? _dataChangeSubscription;
@@ -27,7 +35,16 @@ class PasswordBloc extends Bloc<PasswordEvent, PasswordState> {
     this._deletePassword,
     this._repository,
   ) : super(const PasswordInitial()) {
+    _groupingService = const CredentialGroupingService();
+    _getGroupedHomeEntries = GetGroupedHomeEntriesUseCase(
+      _getPasswords,
+      _groupingService,
+    );
+
     on<LoadPasswords>(_onLoadPasswords);
+    on<SearchPasswords>(_onSearchPasswords);
+    on<FilterPasswords>(_onFilterPasswords);
+    on<ClearPasswordFilters>(_onClearPasswordFilters);
     on<AddPassword>(_onAddPassword);
     on<UpdatePassword>(_onUpdatePassword);
     on<DeletePassword>(_onDeletePassword);
@@ -60,7 +77,7 @@ class PasswordBloc extends Bloc<PasswordEvent, PasswordState> {
   ) async {
     AppLogger.info('Loading passwords from repository', tag: 'PasswordBloc');
     emit(const PasswordLoading());
-    final result = await _getPasswords();
+    final result = await _getGroupedHomeEntries();
     result.fold(
       (failure) {
         AppLogger.error(
@@ -69,13 +86,65 @@ class PasswordBloc extends Bloc<PasswordEvent, PasswordState> {
         );
         emit(PasswordError(failure.message));
       },
-      (passwords) {
+      (payload) {
         AppLogger.info(
-          'Loaded ${passwords.length} passwords',
+          'Loaded ${payload.passwords.length} passwords',
           tag: 'PasswordBloc',
         );
-        emit(PasswordLoaded(passwords));
+        _emitLoaded(
+          emit: emit,
+          passwords: payload.passwords,
+          groupedEntries: payload.groupedEntries,
+        );
       },
+    );
+  }
+
+  void _onSearchPasswords(SearchPasswords event, Emitter<PasswordState> emit) {
+    _searchQuery = event.query.trim().toLowerCase();
+    final currentState = state;
+    if (currentState is! PasswordLoaded) {
+      return;
+    }
+
+    _emitLoaded(
+      emit: emit,
+      passwords: currentState.passwords,
+      groupedEntries: _groupingService.group(currentState.passwords),
+    );
+  }
+
+  void _onFilterPasswords(FilterPasswords event, Emitter<PasswordState> emit) {
+    _folderFilter = event.folder?.trim();
+    _favoritesOnly = event.favoritesOnly;
+    final currentState = state;
+    if (currentState is! PasswordLoaded) {
+      return;
+    }
+
+    _emitLoaded(
+      emit: emit,
+      passwords: currentState.passwords,
+      groupedEntries: _groupingService.group(currentState.passwords),
+    );
+  }
+
+  void _onClearPasswordFilters(
+    ClearPasswordFilters event,
+    Emitter<PasswordState> emit,
+  ) {
+    _searchQuery = '';
+    _folderFilter = null;
+    _favoritesOnly = false;
+    final currentState = state;
+    if (currentState is! PasswordLoaded) {
+      return;
+    }
+
+    _emitLoaded(
+      emit: emit,
+      passwords: currentState.passwords,
+      groupedEntries: _groupingService.group(currentState.passwords),
     );
   }
 
@@ -87,7 +156,7 @@ class PasswordBloc extends Bloc<PasswordEvent, PasswordState> {
     result.fold((failure) => emit(PasswordError(failure.message)), (_) {
       if (state is PasswordLoaded) {
         final currentPasswords = (state as PasswordLoaded).passwords;
-        emit(PasswordLoaded([...currentPasswords, event.entry]));
+        _emitLoadedFromRaw([...currentPasswords, event.entry], emit);
       } else {
         // Fallback: load all if state is not loaded
         add(const LoadPasswords());
@@ -106,7 +175,7 @@ class PasswordBloc extends Bloc<PasswordEvent, PasswordState> {
         final updatedList = currentPasswords.map((p) {
           return p.id == event.entry.id ? event.entry : p;
         }).toList();
-        emit(PasswordLoaded(updatedList));
+        _emitLoadedFromRaw(updatedList, emit);
       } else {
         // Fallback: load all if state is not loaded
         add(const LoadPasswords());
@@ -125,11 +194,85 @@ class PasswordBloc extends Bloc<PasswordEvent, PasswordState> {
         final filteredList = currentPasswords
             .where((p) => p.id != event.id)
             .toList();
-        emit(PasswordLoaded(filteredList));
+        _emitLoadedFromRaw(filteredList, emit);
       } else {
         // Fallback: load all if state is not loaded
         add(const LoadPasswords());
       }
     });
+  }
+
+  void _emitLoadedFromRaw(
+    List<PasswordEntry> passwords,
+    Emitter<PasswordState> emit,
+  ) {
+    _emitLoaded(
+      emit: emit,
+      passwords: passwords,
+      groupedEntries: _groupingService.group(passwords),
+    );
+  }
+
+  void _emitLoaded({
+    required Emitter<PasswordState> emit,
+    required List<PasswordEntry> passwords,
+    required List<GroupedHomeEntry> groupedEntries,
+  }) {
+    emit(
+      PasswordLoaded(
+        passwords: passwords,
+        groupedEntries: _applySearchAndFilters(groupedEntries),
+        searchQuery: _searchQuery,
+        folderFilter: _folderFilter,
+        favoritesOnly: _favoritesOnly,
+      ),
+    );
+  }
+
+  List<GroupedHomeEntry> _applySearchAndFilters(List<GroupedHomeEntry> groups) {
+    if (_searchQuery.isEmpty && _folderFilter == null && !_favoritesOnly) {
+      return groups;
+    }
+
+    final normalizedFolder = _folderFilter?.toLowerCase();
+    final filteredGroups = <GroupedHomeEntry>[];
+
+    for (final group in groups) {
+      final filteredMembers = group.members.where((member) {
+        if (normalizedFolder != null) {
+          final memberFolder = member.folder?.toLowerCase();
+          if (memberFolder != normalizedFolder) {
+            return false;
+          }
+        }
+        if (_favoritesOnly && !member.favorite) {
+          return false;
+        }
+        if (_searchQuery.isEmpty) {
+          return true;
+        }
+
+        final searchableValues = <String>[
+          group.displayName.toLowerCase(),
+          group.canonicalKey.toLowerCase(),
+          member.appName.toLowerCase(),
+          member.username.toLowerCase(),
+          (member.url ?? '').toLowerCase(),
+        ];
+        return searchableValues.any((value) => value.contains(_searchQuery));
+      }).toList();
+
+      if (filteredMembers.isNotEmpty) {
+        filteredGroups.add(
+          GroupedHomeEntry(
+            canonicalKey: group.canonicalKey,
+            displayName: group.displayName,
+            members: filteredMembers,
+          ),
+        );
+      }
+    }
+
+    return filteredGroups;
   }
 }

--- a/lib/features/home/presentation/bloc/password/password_event.dart
+++ b/lib/features/home/presentation/bloc/password/password_event.dart
@@ -11,6 +11,28 @@ class LoadPasswords extends PasswordEvent {
   const LoadPasswords();
 }
 
+class SearchPasswords extends PasswordEvent {
+  final String query;
+  const SearchPasswords(this.query);
+
+  @override
+  List<Object?> get props => [query];
+}
+
+class FilterPasswords extends PasswordEvent {
+  final String? folder;
+  final bool favoritesOnly;
+
+  const FilterPasswords({this.folder, this.favoritesOnly = false});
+
+  @override
+  List<Object?> get props => [folder, favoritesOnly];
+}
+
+class ClearPasswordFilters extends PasswordEvent {
+  const ClearPasswordFilters();
+}
+
 class AddPassword extends PasswordEvent {
   final PasswordEntry entry;
   const AddPassword(this.entry);

--- a/lib/features/home/presentation/bloc/password/password_state.dart
+++ b/lib/features/home/presentation/bloc/password/password_state.dart
@@ -17,10 +17,27 @@ class PasswordLoading extends PasswordState {
 
 class PasswordLoaded extends PasswordState {
   final List<PasswordEntry> passwords;
-  const PasswordLoaded(this.passwords);
+  final List<GroupedHomeEntry> groupedEntries;
+  final String searchQuery;
+  final String? folderFilter;
+  final bool favoritesOnly;
+
+  const PasswordLoaded({
+    required this.passwords,
+    required this.groupedEntries,
+    this.searchQuery = '',
+    this.folderFilter,
+    this.favoritesOnly = false,
+  });
 
   @override
-  List<Object?> get props => [passwords];
+  List<Object?> get props => [
+    passwords,
+    groupedEntries,
+    searchQuery,
+    folderFilter,
+    favoritesOnly,
+  ];
 }
 
 class PasswordError extends PasswordState {

--- a/lib/features/home/presentation/home_screen.dart
+++ b/lib/features/home/presentation/home_screen.dart
@@ -128,9 +128,7 @@ class _HomeScreenGrid extends StatelessWidget {
           index: index,
           child: GroupedPasswordListTile(
             group: groups[index],
-            onTap: () => context.push(
-              AppRoutes.groupedPasswordDetailsPath(groups[index].canonicalKey),
-            ),
+            onTap: () => _onGroupTap(context, groups[index]),
           ),
         ),
         childCount: groups.length,
@@ -152,11 +150,18 @@ class _HomeScreenList extends StatelessWidget {
       itemBuilder: (context, index) => RepaintBoundary(
         child: GroupedPasswordListTile(
           group: groups[index],
-          onTap: () => context.push(
-            AppRoutes.groupedPasswordDetailsPath(groups[index].canonicalKey),
-          ),
+          onTap: () => _onGroupTap(context, groups[index]),
         ),
       ),
     );
   }
+}
+
+void _onGroupTap(BuildContext context, GroupedHomeEntry group) {
+  if (group.accountCount == 1 && group.members.isNotEmpty) {
+    context.push(AppRoutes.editPassword, extra: group.members.first);
+    return;
+  }
+
+  context.push(AppRoutes.groupedPasswordDetailsPath(group.canonicalKey));
 }

--- a/lib/features/home/presentation/home_screen.dart
+++ b/lib/features/home/presentation/home_screen.dart
@@ -6,10 +6,10 @@ import 'package:passvault/config/routes/app_routes.dart';
 import 'package:passvault/core/design_system/components/components.dart';
 import 'package:passvault/core/design_system/theme/theme.dart';
 import 'package:passvault/core/utils/app_semantics.dart';
+import 'package:passvault/features/home/domain/entities/grouped_home_entry.dart';
 import 'package:passvault/features/home/presentation/bloc/password/password_bloc.dart';
 import 'package:passvault/features/home/presentation/widgets/empty_password_state.dart';
-import 'package:passvault/features/home/presentation/widgets/password_list_tile.dart';
-import 'package:passvault/features/password_manager/domain/entities/password_entry.dart';
+import 'package:passvault/features/home/presentation/widgets/grouped_password_list_tile.dart';
 
 /// Main landing screen of the application after authentication.
 class HomeScreen extends StatelessWidget {
@@ -53,7 +53,7 @@ class HomeScreen extends StatelessWidget {
                       ),
                     );
                   } else if (state is PasswordLoaded) {
-                    if (state.passwords.isEmpty) {
+                    if (state.groupedEntries.isEmpty) {
                       return const SliverFillRemaining(
                         child: EmptyPasswordState(),
                       );
@@ -73,8 +73,8 @@ class HomeScreen extends StatelessWidget {
                         bottom: AppSpacing.xxl + fabBottomOffset + fabSize,
                       ),
                       sliver: context.isDesktop || context.isTablet
-                          ? _HomeScreenGrid(passwords: state.passwords)
-                          : _HomeScreenList(passwords: state.passwords),
+                          ? _HomeScreenGrid(groups: state.groupedEntries)
+                          : _HomeScreenList(groups: state.groupedEntries),
                     );
                   } else if (state is PasswordError) {
                     return SliverFillRemaining(
@@ -111,8 +111,8 @@ class HomeScreen extends StatelessWidget {
 }
 
 class _HomeScreenGrid extends StatelessWidget {
-  final List<PasswordEntry> passwords;
-  const _HomeScreenGrid({required this.passwords});
+  final List<GroupedHomeEntry> groups;
+  const _HomeScreenGrid({required this.groups});
 
   @override
   Widget build(BuildContext context) {
@@ -126,38 +126,34 @@ class _HomeScreenGrid extends StatelessWidget {
       delegate: SliverChildBuilderDelegate(
         (context, index) => AppAnimatedListItem(
           index: index,
-          child: PasswordListTile(
-            entry: passwords[index],
-            onTap: () =>
-                context.push(AppRoutes.editPassword, extra: passwords[index]),
-            onDismissed: () => context.read<PasswordBloc>().add(
-              DeletePassword(passwords[index].id),
+          child: GroupedPasswordListTile(
+            group: groups[index],
+            onTap: () => context.push(
+              AppRoutes.groupedPasswordDetailsPath(groups[index].canonicalKey),
             ),
           ),
         ),
-        childCount: passwords.length,
+        childCount: groups.length,
       ),
     );
   }
 }
 
 class _HomeScreenList extends StatelessWidget {
-  final List<PasswordEntry> passwords;
-  const _HomeScreenList({required this.passwords});
+  final List<GroupedHomeEntry> groups;
+  const _HomeScreenList({required this.groups});
 
   @override
   Widget build(BuildContext context) {
     return SliverList.separated(
       separatorBuilder: (context, index) =>
           const SizedBox(height: AppSpacing.m),
-      itemCount: passwords.length,
+      itemCount: groups.length,
       itemBuilder: (context, index) => RepaintBoundary(
-        child: PasswordListTile(
-          entry: passwords[index],
-          onTap: () =>
-              context.push(AppRoutes.editPassword, extra: passwords[index]),
-          onDismissed: () => context.read<PasswordBloc>().add(
-            DeletePassword(passwords[index].id),
+        child: GroupedPasswordListTile(
+          group: groups[index],
+          onTap: () => context.push(
+            AppRoutes.groupedPasswordDetailsPath(groups[index].canonicalKey),
           ),
         ),
       ),

--- a/lib/features/home/presentation/screens/grouped_password_details_screen.dart
+++ b/lib/features/home/presentation/screens/grouped_password_details_screen.dart
@@ -75,52 +75,67 @@ class _GroupedDetailsLoadedScaffold extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text(group.displayName)),
-      body: SafeArea(
-        child: CustomScrollView(
-          slivers: [
-            SliverToBoxAdapter(
+      body: CustomScrollView(
+        slivers: [
+          SliverToBoxAdapter(
+            child: SafeArea(
+              bottom: false,
               child: Padding(
                 padding: const EdgeInsets.fromLTRB(
                   AppSpacing.l,
                   AppSpacing.m,
                   AppSpacing.l,
-                  AppSpacing.m,
+                  AppSpacing.s,
                 ),
-                child: Text(
-                  context.l10n.groupedCredentialCount(group.accountCount),
-                  key: const Key('grouped_details_count_text'),
-                  style: context.typography.titleMedium,
+                child: PageHeader(
+                  title: group.displayName,
+                  showBack: true,
+                  onBack: () => Navigator.of(context).maybePop(),
                 ),
               ),
             ),
-            SliverPadding(
-              key: const Key('grouped_details_member_list'),
+          ),
+          SliverToBoxAdapter(
+            child: Padding(
               padding: const EdgeInsets.fromLTRB(
                 AppSpacing.l,
-                0,
+                AppSpacing.m,
                 AppSpacing.l,
-                AppSpacing.xl,
+                AppSpacing.m,
               ),
-              sliver: SliverList.separated(
-                itemCount: group.members.length,
-                itemBuilder: (context, index) {
-                  final entry = group.members[index];
-                  return PasswordListTile(
-                    entry: entry,
-                    onTap: () =>
-                        context.push(AppRoutes.editPassword, extra: entry),
-                    onDismissed: () => context.read<PasswordBloc>().add(
-                      DeletePassword(entry.id),
-                    ),
-                  );
-                },
-                separatorBuilder: (context, index) =>
-                    const SizedBox(height: AppSpacing.m),
+              child: Text(
+                context.l10n.groupedCredentialCount(group.accountCount),
+                key: const Key('grouped_details_count_text'),
+                style: context.typography.titleMedium,
               ),
             ),
-          ],
-        ),
+          ),
+          SliverPadding(
+            key: const Key('grouped_details_member_list'),
+            padding: const EdgeInsets.fromLTRB(
+              AppSpacing.l,
+              0,
+              AppSpacing.l,
+              AppSpacing.xl,
+            ),
+            sliver: SliverList.separated(
+              itemCount: group.members.length,
+              itemBuilder: (context, index) {
+                final entry = group.members[index];
+                return PasswordListTile(
+                  entry: entry,
+                  onTap: () =>
+                      context.push(AppRoutes.editPassword, extra: entry),
+                  onDismissed: () => context.read<PasswordBloc>().add(
+                    DeletePassword(entry.id),
+                  ),
+                );
+              },
+              separatorBuilder: (context, index) =>
+                  const SizedBox(height: AppSpacing.m),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/features/home/presentation/screens/grouped_password_details_screen.dart
+++ b/lib/features/home/presentation/screens/grouped_password_details_screen.dart
@@ -1,0 +1,127 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+import 'package:passvault/config/routes/app_routes.dart';
+import 'package:passvault/core/design_system/components/components.dart';
+import 'package:passvault/core/design_system/theme/theme.dart';
+import 'package:passvault/features/home/domain/entities/grouped_home_entry.dart';
+import 'package:passvault/features/home/presentation/bloc/password/password_bloc.dart';
+import 'package:passvault/features/home/presentation/widgets/password_list_tile.dart';
+
+class GroupedPasswordDetailsScreen extends StatelessWidget {
+  final String groupKey;
+
+  const GroupedPasswordDetailsScreen({super.key, required this.groupKey});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<PasswordBloc, PasswordState>(
+      builder: (context, state) {
+        if (state is! PasswordLoaded) {
+          return const _GroupedDetailsLoadingScaffold();
+        }
+
+        GroupedHomeEntry? group;
+        for (final entry in state.groupedEntries) {
+          if (entry.canonicalKey == groupKey) {
+            group = entry;
+            break;
+          }
+        }
+        if (group == null) {
+          return const _GroupedDetailsNotFoundScaffold();
+        }
+
+        return _GroupedDetailsLoadedScaffold(group: group);
+      },
+    );
+  }
+}
+
+class _GroupedDetailsLoadingScaffold extends StatelessWidget {
+  const _GroupedDetailsLoadingScaffold();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(),
+      body: const Center(child: AppLoader(key: Key('grouped_details_loading'))),
+    );
+  }
+}
+
+class _GroupedDetailsNotFoundScaffold extends StatelessWidget {
+  const _GroupedDetailsNotFoundScaffold();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(),
+      body: Center(
+        child: Text(
+          context.l10n.groupedEntryNotFound,
+          key: const Key('grouped_details_not_found_text'),
+        ),
+      ),
+    );
+  }
+}
+
+class _GroupedDetailsLoadedScaffold extends StatelessWidget {
+  final GroupedHomeEntry group;
+
+  const _GroupedDetailsLoadedScaffold({required this.group});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(group.displayName)),
+      body: SafeArea(
+        child: CustomScrollView(
+          slivers: [
+            SliverToBoxAdapter(
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(
+                  AppSpacing.l,
+                  AppSpacing.m,
+                  AppSpacing.l,
+                  AppSpacing.m,
+                ),
+                child: Text(
+                  context.l10n.groupedCredentialCount(group.accountCount),
+                  key: const Key('grouped_details_count_text'),
+                  style: context.typography.titleMedium,
+                ),
+              ),
+            ),
+            SliverPadding(
+              key: const Key('grouped_details_member_list'),
+              padding: const EdgeInsets.fromLTRB(
+                AppSpacing.l,
+                0,
+                AppSpacing.l,
+                AppSpacing.xl,
+              ),
+              sliver: SliverList.separated(
+                itemCount: group.members.length,
+                itemBuilder: (context, index) {
+                  final entry = group.members[index];
+                  return PasswordListTile(
+                    entry: entry,
+                    onTap: () =>
+                        context.push(AppRoutes.editPassword, extra: entry),
+                    onDismissed: () => context.read<PasswordBloc>().add(
+                      DeletePassword(entry.id),
+                    ),
+                  );
+                },
+                separatorBuilder: (context, index) =>
+                    const SizedBox(height: AppSpacing.m),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/home/presentation/widgets/grouped_password_list_tile.dart
+++ b/lib/features/home/presentation/widgets/grouped_password_list_tile.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
+import 'package:passvault/core/design_system/components/components.dart';
+import 'package:passvault/core/design_system/theme/theme.dart';
+import 'package:passvault/features/home/domain/entities/grouped_home_entry.dart';
+
+class GroupedPasswordListTile extends StatelessWidget {
+  final GroupedHomeEntry group;
+  final VoidCallback onTap;
+
+  const GroupedPasswordListTile({
+    super.key,
+    required this.group,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AppCard(
+      hasGlow: false,
+      child: InkWell(
+        key: Key('grouped_password_tile_${group.canonicalKey}'),
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(AppRadius.m),
+        child: Row(
+          children: [
+            _GroupLeadingIcon(label: group.displayName),
+            const SizedBox(width: AppSpacing.m),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    group.displayName,
+                    style: context.typography.titleMedium?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  const SizedBox(height: AppSpacing.xs),
+                  Text(
+                    context.l10n.groupedCredentialCount(group.accountCount),
+                    style: context.typography.bodyMedium?.copyWith(
+                      color: context.theme.onSurface.withValues(alpha: 0.7),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            if (group.accountCount > 1)
+              _GroupCountBadge(count: group.accountCount),
+            const SizedBox(width: AppSpacing.s),
+            Icon(
+              LucideIcons.chevronRight,
+              size: AppIconSize.m,
+              color: context.theme.onSurface.withValues(alpha: 0.7),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _GroupLeadingIcon extends StatelessWidget {
+  final String label;
+
+  const _GroupLeadingIcon({required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: AppDimensions.listTileIconSize,
+      height: AppDimensions.listTileIconSize,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: context.theme.primary.withValues(alpha: 0.1),
+          borderRadius: BorderRadius.circular(AppRadius.m),
+        ),
+        child: Center(
+          child: Text(
+            label.isNotEmpty ? label[0].toUpperCase() : '?',
+            style: context.typography.titleMedium?.copyWith(
+              color: context.theme.primary,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _GroupCountBadge extends StatelessWidget {
+  final int count;
+
+  const _GroupCountBadge({required this.count});
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: context.theme.primaryContainer,
+        borderRadius: BorderRadius.circular(AppRadius.xl),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.s,
+          vertical: AppSpacing.xs,
+        ),
+        child: Text(
+          count.toString(),
+          key: const Key('grouped_password_count_badge'),
+          style: context.typography.labelMedium?.copyWith(
+            color: context.theme.onPrimaryContainer,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/home/presentation/widgets/grouped_password_list_tile.dart
+++ b/lib/features/home/presentation/widgets/grouped_password_list_tile.dart
@@ -16,6 +16,11 @@ class GroupedPasswordListTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final isSingleAccount = group.accountCount == 1;
+    final subtitle = isSingleAccount
+        ? ''
+        : context.l10n.groupedCredentialCount(group.accountCount);
+
     return AppCard(
       hasGlow: false,
       child: InkWell(
@@ -36,18 +41,19 @@ class GroupedPasswordListTile extends StatelessWidget {
                       fontWeight: FontWeight.bold,
                     ),
                   ),
-                  const SizedBox(height: AppSpacing.xs),
-                  Text(
-                    context.l10n.groupedCredentialCount(group.accountCount),
-                    style: context.typography.bodyMedium?.copyWith(
-                      color: context.theme.onSurface.withValues(alpha: 0.7),
+                  if (subtitle.isNotEmpty) ...[
+                    const SizedBox(height: AppSpacing.xs),
+                    Text(
+                      subtitle,
+                      style: context.typography.bodyMedium?.copyWith(
+                        color: context.theme.onSurface.withValues(alpha: 0.7),
+                      ),
                     ),
-                  ),
+                  ],
                 ],
               ),
             ),
-            if (group.accountCount > 1)
-              _GroupCountBadge(count: group.accountCount),
+            if (!isSingleAccount) _GroupCountBadge(count: group.accountCount),
             const SizedBox(width: AppSpacing.s),
             Icon(
               LucideIcons.chevronRight,

--- a/lib/features/home/presentation/widgets/grouped_password_list_tile.dart
+++ b/lib/features/home/presentation/widgets/grouped_password_list_tile.dart
@@ -53,7 +53,6 @@ class GroupedPasswordListTile extends StatelessWidget {
                 ],
               ),
             ),
-            if (!isSingleAccount) _GroupCountBadge(count: group.accountCount),
             const SizedBox(width: AppSpacing.s),
             Icon(
               LucideIcons.chevronRight,
@@ -88,36 +87,6 @@ class _GroupLeadingIcon extends StatelessWidget {
             style: context.typography.titleMedium?.copyWith(
               color: context.theme.primary,
             ),
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _GroupCountBadge extends StatelessWidget {
-  final int count;
-
-  const _GroupCountBadge({required this.count});
-
-  @override
-  Widget build(BuildContext context) {
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        color: context.theme.primaryContainer,
-        borderRadius: BorderRadius.circular(AppRadius.xl),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(
-          horizontal: AppSpacing.s,
-          vertical: AppSpacing.xs,
-        ),
-        child: Text(
-          count.toString(),
-          key: const Key('grouped_password_count_badge'),
-          style: context.typography.labelMedium?.copyWith(
-            color: context.theme.onPrimaryContainer,
-            fontWeight: FontWeight.w600,
           ),
         ),
       ),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -162,6 +162,15 @@
   "savePassword": "Save Password",
   "updatePassword": "Update Password",
   "entryNotFound": "Password entry not found",
+  "groupedEntryNotFound": "Grouped entry not found",
+  "groupedCredentialCount": "{count, plural, =0{No accounts} =1{1 account} other{{count} accounts}}",
+  "@groupedCredentialCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "wordCountLabel": "Word Count",
   "separatorLabel": "Separator",
   "separatorNone": "None",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -898,6 +898,18 @@ abstract class AppLocalizations {
   /// **'Password entry not found'**
   String get entryNotFound;
 
+  /// No description provided for @groupedEntryNotFound.
+  ///
+  /// In en, this message translates to:
+  /// **'Grouped entry not found'**
+  String get groupedEntryNotFound;
+
+  /// No description provided for @groupedCredentialCount.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =0{No accounts} =1{1 account} other{{count} accounts}}'**
+  String groupedCredentialCount(int count);
+
   /// No description provided for @wordCountLabel.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -429,6 +429,21 @@ class AppLocalizationsEn extends AppLocalizations {
   String get entryNotFound => 'Password entry not found';
 
   @override
+  String get groupedEntryNotFound => 'Grouped entry not found';
+
+  @override
+  String groupedCredentialCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count accounts',
+      one: '1 account',
+      zero: 'No accounts',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get wordCountLabel => 'Word Count';
 
   @override

--- a/test/features/home/domain/services/credential_grouping_service_test.dart
+++ b/test/features/home/domain/services/credential_grouping_service_test.dart
@@ -51,7 +51,7 @@ void main() {
             id: '2',
             appName: 'Example',
             username: 'second@example.com',
-            url: '  HTTP://example.com ',
+            url: '  HTTP://example.com/path/login ',
           ),
           makeEntry(id: '3', appName: 'Standalone App', username: 'app-user'),
           makeEntry(
@@ -78,6 +78,209 @@ void main() {
           contains('standalone app'),
         );
         expect(grouped.map((group) => group.canonicalKey), contains('id-only'));
+      },
+    );
+
+    test(
+      'extracts host for path-heavy web urls and uses host as display name',
+      () {
+        final entries = [
+          makeEntry(
+            id: 'mc-1',
+            appName: 'Moneycontrol',
+            username: 'u1',
+            url: 'https://accounts.moneycontrol.com/mc/login/',
+          ),
+          makeEntry(
+            id: 'mc-2',
+            appName: 'Moneycontrol',
+            username: 'u2',
+            url: 'accounts.moneycontrol.com/auth/signin',
+          ),
+        ];
+
+        final grouped = service.group(entries);
+        final moneycontrolGroup = grouped.firstWhere(
+          (group) => group.canonicalKey == 'moneycontrol.com',
+        );
+
+        expect(moneycontrolGroup.displayName, 'moneycontrol.com');
+        expect(moneycontrolGroup.accountCount, 2);
+      },
+    );
+
+    test(
+      'collapses known login-style and ww-prefix subdomains to base domain',
+      () {
+        final entries = [
+          makeEntry(
+            id: 'x-1',
+            appName: 'XYZ',
+            username: 'u1',
+            url: 'https://wwe.xyz.com/signin',
+          ),
+          makeEntry(
+            id: 'x-2',
+            appName: 'XYZ',
+            username: 'u2',
+            url: 'https://xyz.com',
+          ),
+          makeEntry(
+            id: 'x-3',
+            appName: 'XYZ',
+            username: 'u3',
+            url: 'https://accounts.xyz.com/oauth/authorize',
+          ),
+        ];
+
+        final grouped = service.group(entries);
+        final xyzGroup = grouped.firstWhere(
+          (group) => group.canonicalKey == 'xyz.com',
+        );
+
+        expect(xyzGroup.displayName, 'xyz.com');
+        expect(xyzGroup.accountCount, 3);
+      },
+    );
+
+    test('keeps unrelated tenant-style subdomains distinct', () {
+      final entries = [
+        makeEntry(
+          id: 'tenant-1',
+          appName: 'Tenant',
+          username: 'u1',
+          url: 'https://team1.example.com',
+        ),
+        makeEntry(
+          id: 'tenant-2',
+          appName: 'Tenant',
+          username: 'u2',
+          url: 'https://example.com',
+        ),
+      ];
+
+      final grouped = service.group(entries);
+      expect(grouped.length, 2);
+      expect(
+        grouped.map((group) => group.canonicalKey),
+        containsAll(['team1.example.com', 'example.com']),
+      );
+    });
+
+    test('parses android credential realm and prettifies app label', () {
+      final entries = [
+        makeEntry(
+          id: 'android-1',
+          appName: '',
+          username: 'u1',
+          url: 'android://abcdef12345@com.freelancer.android.messenger/',
+        ),
+        makeEntry(
+          id: 'android-2',
+          appName: '',
+          username: 'u2',
+          url: 'android://xyz987@com.freelancer.android.messenger/',
+        ),
+      ];
+
+      final grouped = service.group(entries);
+      final androidGroup = grouped.firstWhere(
+        (group) =>
+            group.canonicalKey == 'android:com.freelancer.android.messenger',
+      );
+
+      expect(androidGroup.displayName, 'Freelancer');
+      expect(androidGroup.accountCount, 2);
+    });
+
+    test(
+      'uses stored appName over prettified package when appName is non-empty',
+      () {
+        final entries = [
+          makeEntry(
+            id: 'irctc-1',
+            appName: 'IRCTC Rail Connect',
+            username: 'dhruvanbhalara',
+            url: 'android://someHash@com.cris.android/',
+          ),
+        ];
+
+        final grouped = service.group(entries);
+        final irctcGroup = grouped.firstWhere(
+          (group) => group.canonicalKey == 'android:com.cris.android',
+        );
+
+        expect(irctcGroup.displayName, 'IRCTC Rail Connect');
+        expect(irctcGroup.accountCount, 1);
+      },
+    );
+
+    test('uses stored appName for contextlogic wish android entry', () {
+      final entries = [
+        makeEntry(
+          id: 'wish-1',
+          appName: 'Wish - Shopping Made Fun',
+          username: 'user@example.com',
+          url: 'android://someHash@com.contextlogic.wish/',
+        ),
+      ];
+
+      final grouped = service.group(entries);
+      final wishGroup = grouped.firstWhere(
+        (group) => group.canonicalKey == 'android:com.contextlogic.wish',
+      );
+
+      expect(wishGroup.displayName, 'Wish - Shopping Made Fun');
+    });
+
+    test(
+      'uses first appName when multiple accounts share the same android package',
+      () {
+        final entries = [
+          makeEntry(
+            id: 'fb-1',
+            appName: 'Facebook',
+            username: 'alice@example.com',
+            url: 'android://hashA@com.facebook.katana/',
+            lastUpdated: DateTime(2026, 1, 2),
+          ),
+          makeEntry(
+            id: 'fb-2',
+            appName: 'Facebook',
+            username: 'bob@example.com',
+            url: 'android://hashB@com.facebook.katana/',
+            lastUpdated: DateTime(2026, 1, 1),
+          ),
+        ];
+
+        final grouped = service.group(entries);
+        final fbGroup = grouped.firstWhere(
+          (group) => group.canonicalKey == 'android:com.facebook.katana',
+        );
+
+        expect(fbGroup.displayName, 'Facebook');
+        expect(fbGroup.accountCount, 2);
+      },
+    );
+
+    test(
+      'falls back to prettified package when appName is only whitespace',
+      () {
+        final entries = [
+          makeEntry(
+            id: 'ws-1',
+            appName: '   ',
+            username: 'u1',
+            url: 'android://hashXYZ@com.freelancer.android.messenger/',
+          ),
+        ];
+
+        final grouped = service.group(entries);
+        final group = grouped.firstWhere(
+          (g) => g.canonicalKey == 'android:com.freelancer.android.messenger',
+        );
+
+        expect(group.displayName, 'Freelancer');
       },
     );
 

--- a/test/features/home/domain/services/credential_grouping_service_test.dart
+++ b/test/features/home/domain/services/credential_grouping_service_test.dart
@@ -1,0 +1,132 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:passvault/features/home/domain/services/credential_grouping_service.dart';
+import 'package:passvault/features/password_manager/domain/entities/password_entry.dart';
+
+void main() {
+  const className = 'CredentialGroupingService';
+
+  PasswordEntry makeEntry({
+    required String id,
+    required String appName,
+    required String username,
+    String? url,
+    String? folder,
+    bool favorite = false,
+    DateTime? lastUpdated,
+  }) {
+    return PasswordEntry(
+      id: id,
+      appName: appName,
+      username: username,
+      password: 'pw',
+      lastUpdated: lastUpdated ?? DateTime(2026, 1, 1),
+      url: url,
+      folder: folder,
+      favorite: favorite,
+    );
+  }
+
+  group(className, () {
+    const service = CredentialGroupingService();
+
+    test('normalizes target in locked order', () {
+      final normalized = service.canonicalizeTarget(
+        '  HTTPS://WWW.Example.Com ',
+      );
+
+      expect(normalized, 'example.com');
+    });
+
+    test(
+      'uses fallback chain url appName id and preserves all credentials',
+      () {
+        final entries = [
+          makeEntry(
+            id: '1',
+            appName: 'Example',
+            username: 'first@example.com',
+            url: 'https://www.example.com',
+          ),
+          makeEntry(
+            id: '2',
+            appName: 'Example',
+            username: 'second@example.com',
+            url: '  HTTP://example.com ',
+          ),
+          makeEntry(id: '3', appName: 'Standalone App', username: 'app-user'),
+          makeEntry(
+            id: 'id-only',
+            appName: '  ',
+            username: 'id-user',
+            url: '   ',
+          ),
+        ];
+
+        final grouped = service.group(entries);
+        final totalMembers = grouped.fold<int>(
+          0,
+          (sum, group) => sum + group.members.length,
+        );
+
+        expect(totalMembers, entries.length);
+        expect(
+          grouped.map((group) => group.canonicalKey),
+          contains('example.com'),
+        );
+        expect(
+          grouped.map((group) => group.canonicalKey),
+          contains('standalone app'),
+        );
+        expect(grouped.map((group) => group.canonicalKey), contains('id-only'));
+      },
+    );
+
+    test(
+      'groups and members are deterministically ordered with id tie-breaker',
+      () {
+        final entries = [
+          makeEntry(
+            id: 'b',
+            appName: 'Gamma',
+            username: 'same-user',
+            url: 'https://gamma.com',
+            lastUpdated: DateTime(2026, 1, 1),
+          ),
+          makeEntry(
+            id: 'a',
+            appName: 'Gamma',
+            username: 'same-user',
+            url: 'https://www.gamma.com',
+            lastUpdated: DateTime(2026, 1, 1),
+          ),
+          makeEntry(
+            id: '3',
+            appName: 'Beta',
+            username: 'z-user',
+            url: 'https://beta.com',
+          ),
+          makeEntry(
+            id: '4',
+            appName: 'Alpha',
+            username: 'a-user',
+            url: 'https://alpha.com',
+          ),
+        ];
+
+        final grouped = service.group(entries);
+        final orderedGroupKeys = grouped
+            .map((group) => group.canonicalKey)
+            .toList();
+        final gammaGroup = grouped.firstWhere(
+          (group) => group.canonicalKey == 'gamma.com',
+        );
+        final gammaMemberIds = gammaGroup.members
+            .map((member) => member.id)
+            .toList();
+
+        expect(orderedGroupKeys, ['alpha.com', 'beta.com', 'gamma.com']);
+        expect(gammaMemberIds, ['a', 'b']);
+      },
+    );
+  });
+}

--- a/test/features/home/domain/services/credential_grouping_service_test.dart
+++ b/test/features/home/domain/services/credential_grouping_service_test.dart
@@ -82,7 +82,7 @@ void main() {
     );
 
     test(
-      'extracts host for path-heavy web urls and uses host as display name',
+      'extracts host for path-heavy web urls and prefers appName as display name',
       () {
         final entries = [
           makeEntry(
@@ -104,68 +104,68 @@ void main() {
           (group) => group.canonicalKey == 'moneycontrol.com',
         );
 
-        expect(moneycontrolGroup.displayName, 'moneycontrol.com');
+        expect(moneycontrolGroup.displayName, 'Moneycontrol');
         expect(moneycontrolGroup.accountCount, 2);
       },
     );
 
-    test(
-      'collapses known login-style and ww-prefix subdomains to base domain',
-      () {
-        final entries = [
-          makeEntry(
-            id: 'x-1',
-            appName: 'XYZ',
-            username: 'u1',
-            url: 'https://wwe.xyz.com/signin',
-          ),
-          makeEntry(
-            id: 'x-2',
-            appName: 'XYZ',
-            username: 'u2',
-            url: 'https://xyz.com',
-          ),
-          makeEntry(
-            id: 'x-3',
-            appName: 'XYZ',
-            username: 'u3',
-            url: 'https://accounts.xyz.com/oauth/authorize',
-          ),
-        ];
-
-        final grouped = service.group(entries);
-        final xyzGroup = grouped.firstWhere(
-          (group) => group.canonicalKey == 'xyz.com',
-        );
-
-        expect(xyzGroup.displayName, 'xyz.com');
-        expect(xyzGroup.accountCount, 3);
-      },
-    );
-
-    test('keeps unrelated tenant-style subdomains distinct', () {
+    test('collapses all subdomains to their base registrable domain', () {
       final entries = [
         makeEntry(
-          id: 'tenant-1',
-          appName: 'Tenant',
+          id: 'x-1',
+          appName: 'XYZ',
           username: 'u1',
-          url: 'https://team1.example.com',
+          url: 'https://wwe.xyz.com/signin',
         ),
         makeEntry(
-          id: 'tenant-2',
-          appName: 'Tenant',
+          id: 'x-2',
+          appName: 'XYZ',
           username: 'u2',
-          url: 'https://example.com',
+          url: 'https://xyz.com',
+        ),
+        makeEntry(
+          id: 'x-3',
+          appName: 'XYZ',
+          username: 'u3',
+          url: 'https://accounts.xyz.com/oauth/authorize',
         ),
       ];
 
       final grouped = service.group(entries);
-      expect(grouped.length, 2);
-      expect(
-        grouped.map((group) => group.canonicalKey),
-        containsAll(['team1.example.com', 'example.com']),
+      final xyzGroup = grouped.firstWhere(
+        (group) => group.canonicalKey == 'xyz.com',
       );
+
+      expect(xyzGroup.displayName, 'XYZ');
+      expect(xyzGroup.accountCount, 3);
     });
+
+    test(
+      'collapses tenant-style subdomains to the base registrable domain',
+      () {
+        final entries = [
+          makeEntry(
+            id: 'tenant-1',
+            appName: 'Tenant',
+            username: 'u1',
+            url: 'https://team1.example.com',
+          ),
+          makeEntry(
+            id: 'tenant-2',
+            appName: 'Tenant',
+            username: 'u2',
+            url: 'https://example.com',
+          ),
+        ];
+
+        final grouped = service.group(entries);
+        expect(grouped.length, 1);
+        final exampleGroup = grouped.firstWhere(
+          (group) => group.canonicalKey == 'example.com',
+        );
+        expect(exampleGroup.accountCount, 2);
+      },
+    );
 
     test('parses android credential realm and prettifies app label', () {
       final entries = [
@@ -191,6 +191,40 @@ void main() {
 
       expect(androidGroup.displayName, 'Freelancer');
       expect(androidGroup.accountCount, 2);
+    });
+
+    test('prefers representative stored appName for group display label', () {
+      final entries = [
+        makeEntry(
+          id: 'wish-web',
+          appName: 'wish.com',
+          username: 'u1',
+          url: 'https://wish.com',
+          lastUpdated: DateTime(2026, 1, 3),
+        ),
+        makeEntry(
+          id: 'wish-android',
+          appName: 'Wish',
+          username: 'u2',
+          url: 'android://hash@com.contextlogic.wish/',
+          lastUpdated: DateTime(2026, 1, 4),
+        ),
+        makeEntry(
+          id: 'wish-android-2',
+          appName: 'Wish',
+          username: 'u3',
+          url: 'android://hash2@com.contextlogic.wish/',
+          lastUpdated: DateTime(2026, 1, 5),
+        ),
+      ];
+
+      final grouped = service.group(entries);
+      final wishGroup = grouped.firstWhere(
+        (group) => group.canonicalKey == 'android:com.contextlogic.wish',
+      );
+
+      expect(wishGroup.displayName, 'Wish');
+      expect(wishGroup.accountCount, 2);
     });
 
     test(
@@ -329,6 +363,172 @@ void main() {
 
         expect(orderedGroupKeys, ['alpha.com', 'beta.com', 'gamma.com']);
         expect(gammaMemberIds, ['a', 'b']);
+      },
+    );
+
+    group('Registrable domain collation tests', () {
+      test('collapses deeply nested subdomains to base domain', () {
+        final entries = [
+          makeEntry(
+            id: 'nested',
+            appName: 'Nested',
+            username: 'u1',
+            url: 'https://a.b.c.example.com',
+          ),
+        ];
+        final grouped = service.group(entries);
+        expect(grouped.first.canonicalKey, 'example.com');
+      });
+
+      test(
+        'handles common ccTLDs correctly recognizing the registry suffix',
+        () {
+          final entries = [
+            makeEntry(
+              id: 'cctld',
+              appName: 'UK Site',
+              username: 'u1',
+              url: 'https://app.example.co.uk',
+            ),
+          ];
+          final grouped = service.group(entries);
+          expect(grouped.first.canonicalKey, 'example.co.uk');
+        },
+      );
+
+      test('handles base level domains or local networks without failure', () {
+        final entries = [
+          makeEntry(
+            id: 'local',
+            appName: 'Local',
+            username: 'u1',
+            url: 'http://example.local',
+          ),
+          makeEntry(
+            id: 'base',
+            appName: 'Base',
+            username: 'u2',
+            url: 'https://example.com',
+          ),
+        ];
+        final grouped = service.group(entries);
+        expect(grouped.length, 2);
+        expect(
+          grouped.map((g) => g.canonicalKey),
+          containsAll(['example.local', 'example.com']),
+        );
+      });
+
+      test('collapses previously unhandled obscure subdomains perfectly', () {
+        final entries = [
+          makeEntry(
+            id: 'obscure',
+            appName: 'Obscure',
+            username: 'u1',
+            url: 'https://my-secret-tenant.example.com',
+          ),
+        ];
+        final grouped = service.group(entries);
+        expect(grouped.first.canonicalKey, 'example.com');
+      });
+
+      test('keeps different base domains strictly separate', () {
+        final entries = [
+          makeEntry(
+            id: 'app1',
+            appName: 'App1',
+            username: 'u1',
+            url: 'https://app.example1.com',
+          ),
+          makeEntry(
+            id: 'app2',
+            appName: 'App2',
+            username: 'u2',
+            url: 'https://app.example2.com',
+          ),
+        ];
+        final grouped = service.group(entries);
+        expect(grouped.length, 2);
+        expect(
+          grouped.map((g) => g.canonicalKey),
+          containsAll(['example1.com', 'example2.com']),
+        );
+      });
+    });
+
+    group(
+      'Android package prettification tests (without hardcoded overrides)',
+      () {
+        test('prettifies simple android package name missing appName', () {
+          final entries = [
+            makeEntry(
+              id: 'simple',
+              appName: '',
+              username: 'u1',
+              url: 'android://hash@com.freelancer.android.messenger/',
+            ),
+          ];
+          final grouped = service.group(entries);
+          expect(grouped.first.displayName, 'Freelancer');
+        });
+
+        test(
+          'prettifies dot-separated names like cris.org.in.prs.ima gracefully',
+          () {
+            final entries = [
+              makeEntry(
+                id: 'cris',
+                appName: '',
+                username: 'u1',
+                url: 'android://hash@cris.org.in.prs.ima/',
+              ),
+            ];
+            final grouped = service.group(entries);
+            expect(grouped.first.displayName, 'Cris');
+          },
+        );
+
+        test('prettifies complex package with underscores and hyphens', () {
+          final entries = [
+            makeEntry(
+              id: 'complex',
+              appName: '',
+              username: 'u1',
+              url: 'android://hash@com.my_app-corp.mobile/',
+            ),
+          ];
+          final grouped = service.group(entries);
+          expect(grouped.first.displayName, 'My app corp');
+        });
+
+        test(
+          'prettifies package containing the word android in different casing',
+          () {
+            final entries = [
+              makeEntry(
+                id: 'android-case',
+                appName: '',
+                username: 'u1',
+                url: 'android://hash@com.AnDroiDCorp.app/',
+              ),
+            ];
+            final grouped = service.group(entries);
+            expect(grouped.first.displayName, 'Corp');
+          },
+        );
+
+        test('returns raw package strictly if stripping leaves it empty', () {
+          final entries = [
+            makeEntry(
+              id: 'empty',
+              appName: '',
+              username: 'u1',
+              url: 'android://hash@com.android.org/',
+            ),
+          ];
+          final grouped = service.group(entries);
+          expect(grouped.first.displayName, 'com.android.org');
+        });
       },
     );
   });

--- a/test/features/home/domain/usecases/get_grouped_home_entries_usecase_test.dart
+++ b/test/features/home/domain/usecases/get_grouped_home_entries_usecase_test.dart
@@ -1,0 +1,86 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:passvault/core/error/failures.dart';
+import 'package:passvault/core/error/result.dart';
+import 'package:passvault/features/home/domain/services/credential_grouping_service.dart';
+import 'package:passvault/features/home/domain/usecases/get_grouped_home_entries_usecase.dart';
+import 'package:passvault/features/password_manager/domain/entities/password_entry.dart';
+import 'package:passvault/features/password_manager/domain/usecases/password_usecases.dart';
+
+class _MockGetPasswordsUseCase extends Mock implements GetPasswordsUseCase {}
+
+void main() {
+  const className = 'GetGroupedHomeEntriesUseCase';
+  late _MockGetPasswordsUseCase getPasswordsUseCase;
+  late GetGroupedHomeEntriesUseCase useCase;
+
+  PasswordEntry makeEntry({
+    required String id,
+    required String appName,
+    required String username,
+    String? url,
+  }) {
+    return PasswordEntry(
+      id: id,
+      appName: appName,
+      username: username,
+      password: 'pw',
+      lastUpdated: DateTime(2026, 1, 1),
+      url: url,
+    );
+  }
+
+  setUp(() {
+    getPasswordsUseCase = _MockGetPasswordsUseCase();
+    useCase = GetGroupedHomeEntriesUseCase(
+      getPasswordsUseCase,
+      const CredentialGroupingService(),
+    );
+  });
+
+  group(className, () {
+    test('returns grouped payload when repository call succeeds', () async {
+      final rawEntries = [
+        makeEntry(
+          id: '1',
+          appName: 'Example',
+          username: 'first',
+          url: 'https://www.example.com',
+        ),
+        makeEntry(
+          id: '2',
+          appName: 'Example',
+          username: 'second',
+          url: 'http://example.com',
+        ),
+      ];
+      when(
+        () => getPasswordsUseCase(),
+      ).thenAnswer((_) async => Success(rawEntries));
+
+      final result = await useCase();
+
+      expect(result, isA<Success<GroupedHomeEntriesPayload>>());
+      final payload = (result as Success<GroupedHomeEntriesPayload>).data;
+      expect(payload.passwords, rawEntries);
+      expect(payload.groupedEntries.length, 1);
+      expect(payload.groupedEntries.single.canonicalKey, 'example.com');
+      expect(payload.groupedEntries.single.members.length, rawEntries.length);
+    });
+
+    test('forwards failure when password retrieval fails', () async {
+      when(
+        () => getPasswordsUseCase(),
+      ).thenAnswer((_) async => const Error(DatabaseFailure('storage-failed')));
+
+      final result = await useCase();
+
+      expect(
+        result,
+        const Error<GroupedHomeEntriesPayload>(
+          DatabaseFailure('storage-failed'),
+        ),
+      );
+    });
+  });
+}

--- a/test/features/home/presentation/bloc/password_bloc_test.dart
+++ b/test/features/home/presentation/bloc/password_bloc_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:passvault/core/error/failures.dart';
 import 'package:passvault/core/error/result.dart';
+import 'package:passvault/features/home/domain/entities/grouped_home_entry.dart';
 import 'package:passvault/features/home/presentation/bloc/password/password_bloc.dart';
 import 'package:passvault/features/password_manager/domain/entities/password_entry.dart';
 import 'package:passvault/features/password_manager/domain/repositories/password_repository.dart';
@@ -19,19 +20,36 @@ class MockDeletePasswordUseCase extends Mock implements DeletePasswordUseCase {}
 class MockPasswordRepository extends Mock implements PasswordRepository {}
 
 void main() {
+  const className = 'PasswordBloc';
   late PasswordBloc bloc;
   late MockGetPasswordsUseCase mockGetPasswords;
   late MockSavePasswordUseCase mockSavePassword;
   late MockDeletePasswordUseCase mockDeletePassword;
   late MockPasswordRepository mockRepository;
 
-  final tEntry = PasswordEntry(
+  final entryOne = PasswordEntry(
     id: '1',
-    appName: 'App1',
-    username: 'user1',
+    appName: 'Example',
+    username: 'first@example.com',
     password: 'pass1',
-    lastUpdated: DateTime(2024, 1, 1),
+    lastUpdated: DateTime(2026, 1, 1),
+    url: 'https://www.example.com',
+    folder: 'work',
+    favorite: true,
   );
+  final entryTwo = PasswordEntry(
+    id: '2',
+    appName: 'Example',
+    username: 'second@example.com',
+    password: 'pass2',
+    lastUpdated: DateTime(2026, 1, 2),
+    url: 'http://example.com',
+    folder: 'personal',
+  );
+
+  setUpAll(() {
+    registerFallbackValue(entryOne);
+  });
 
   setUp(() {
     mockGetPasswords = MockGetPasswordsUseCase();
@@ -51,245 +69,309 @@ void main() {
     );
   });
 
-  setUpAll(() {
-    registerFallbackValue(tEntry);
-  });
-
   tearDown(() => bloc.close());
 
-  group('$PasswordBloc', () {
+  Matcher loadedStateWith({
+    required List<PasswordEntry> passwords,
+    required int groupedCount,
+    required int groupedMemberTotal,
+  }) {
+    return isA<PasswordLoaded>()
+        .having((state) => state.passwords, 'passwords', passwords)
+        .having(
+          (state) => state.groupedEntries.length,
+          'groupedEntries.length',
+          groupedCount,
+        )
+        .having(
+          (state) => state.groupedEntries.fold<int>(
+            0,
+            (sum, group) => sum + group.members.length,
+          ),
+          'grouped member total',
+          groupedMemberTotal,
+        );
+  }
+
+  group(className, () {
     test('initial state is PasswordInitial', () {
       expect(bloc.state, const PasswordInitial());
     });
 
     blocTest<PasswordBloc, PasswordState>(
-      'on LoadPasswords should emit [Loading, Loaded] on success',
+      'LoadPasswords emits grouped loaded state on success',
       build: () {
         when(
           () => mockGetPasswords(),
-        ).thenAnswer((_) async => Success([tEntry]));
+        ).thenAnswer((_) async => Success([entryOne, entryTwo]));
         return bloc;
       },
-      act: (bloc) => bloc.add(const LoadPasswords()),
+      act: (testBloc) => testBloc.add(const LoadPasswords()),
       expect: () => [
         const PasswordLoading(),
-        PasswordLoaded([tEntry]),
+        loadedStateWith(
+          passwords: [entryOne, entryTwo],
+          groupedCount: 1,
+          groupedMemberTotal: 2,
+        ),
       ],
       verify: (_) => verify(() => mockGetPasswords()).called(1),
     );
 
     blocTest<PasswordBloc, PasswordState>(
-      'on AddPassword should update state incrementally if already loaded',
-      build: () {
-        when(
-          () => mockSavePassword(any()),
-        ).thenAnswer((_) async => const Success(null));
-        return bloc;
-      },
-      seed: () => PasswordLoaded([tEntry]),
-      act: (bloc) =>
-          bloc.add(AddPassword(tEntry.copyWith(id: '2', appName: 'App2'))),
-      expect: () => [
-        PasswordLoaded([tEntry, tEntry.copyWith(id: '2', appName: 'App2')]),
-      ],
-      verify: (_) {
-        verify(() => mockSavePassword(any())).called(1);
-        verifyNever(() => mockGetPasswords());
-      },
-    );
-
-    blocTest<PasswordBloc, PasswordState>(
-      'on UpdatePassword should update state incrementally if already loaded',
-      build: () {
-        when(
-          () => mockSavePassword(any()),
-        ).thenAnswer((_) async => const Success(null));
-        return bloc;
-      },
-      seed: () => PasswordLoaded([tEntry]),
-      act: (bloc) =>
-          bloc.add(UpdatePassword(tEntry.copyWith(appName: 'Updated App'))),
-      expect: () => [
-        PasswordLoaded([tEntry.copyWith(appName: 'Updated App')]),
-      ],
-      verify: (_) {
-        verify(() => mockSavePassword(any())).called(1);
-        verifyNever(() => mockGetPasswords());
-      },
-    );
-
-    blocTest<PasswordBloc, PasswordState>(
-      'on DeletePassword should remove from state incrementally if already loaded',
-      build: () {
-        when(
-          () => mockDeletePassword(any()),
-        ).thenAnswer((_) async => const Success(null));
-        return bloc;
-      },
-      seed: () => PasswordLoaded([tEntry]),
-      act: (bloc) => bloc.add(const DeletePassword('1')),
-      expect: () => [const PasswordLoaded([])],
-      verify: (_) {
-        verify(() => mockDeletePassword('1')).called(1);
-        verifyNever(() => mockGetPasswords());
-      },
-    );
-
-    blocTest<PasswordBloc, PasswordState>(
-      'on LoadPasswords should emit [Loading, Error] on failure',
+      'LoadPasswords emits error state on failure',
       build: () {
         when(
           () => mockGetPasswords(),
         ).thenAnswer((_) async => const Error(DatabaseFailure('error')));
         return bloc;
       },
-      act: (bloc) => bloc.add(const LoadPasswords()),
+      act: (testBloc) => testBloc.add(const LoadPasswords()),
       expect: () => [const PasswordLoading(), const PasswordError('error')],
     );
 
-    group('Error and Fallback branches', () {
-      blocTest<PasswordBloc, PasswordState>(
-        'on AddPassword should reload if state is not PasswordLoaded',
-        build: () {
-          when(
-            () => mockSavePassword(any()),
-          ).thenAnswer((_) async => const Success(null));
-          when(
-            () => mockGetPasswords(),
-          ).thenAnswer((_) async => Success([tEntry]));
-          return bloc;
-        },
-        act: (bloc) => bloc.add(AddPassword(tEntry)),
-        expect: () => [
-          const PasswordLoading(),
-          PasswordLoaded([tEntry]),
+    blocTest<PasswordBloc, PasswordState>(
+      'AddPassword updates loaded state incrementally and preserves grouping',
+      build: () {
+        when(
+          () => mockSavePassword(any()),
+        ).thenAnswer((_) async => const Success(null));
+        return bloc;
+      },
+      seed: () => PasswordLoaded(
+        passwords: [entryOne],
+        groupedEntries: const [
+          GroupedHomeEntry(
+            canonicalKey: 'example.com',
+            displayName: 'example.com',
+            members: [],
+          ),
         ],
-        verify: (_) {
-          verify(() => mockSavePassword(any())).called(1);
-          verify(() => mockGetPasswords()).called(1);
-        },
+      ),
+      act: (testBloc) => testBloc.add(AddPassword(entryTwo)),
+      expect: () => [
+        loadedStateWith(
+          passwords: [entryOne, entryTwo],
+          groupedCount: 1,
+          groupedMemberTotal: 2,
+        ),
+      ],
+      verify: (_) {
+        verify(() => mockSavePassword(any())).called(1);
+        verifyNever(() => mockGetPasswords());
+      },
+    );
+
+    blocTest<PasswordBloc, PasswordState>(
+      'UpdatePassword updates member and preserves grouped structure',
+      build: () {
+        when(
+          () => mockSavePassword(any()),
+        ).thenAnswer((_) async => const Success(null));
+        return bloc;
+      },
+      seed: () =>
+          PasswordLoaded(passwords: [entryOne], groupedEntries: const []),
+      act: (testBloc) => testBloc.add(
+        UpdatePassword(entryOne.copyWith(username: 'new@example.com')),
+      ),
+      expect: () => [
+        loadedStateWith(
+          passwords: [entryOne.copyWith(username: 'new@example.com')],
+          groupedCount: 1,
+          groupedMemberTotal: 1,
+        ),
+      ],
+    );
+
+    blocTest<PasswordBloc, PasswordState>(
+      'DeletePassword removes entry and preserves total count invariant',
+      build: () {
+        when(
+          () => mockDeletePassword(any()),
+        ).thenAnswer((_) async => const Success(null));
+        return bloc;
+      },
+      seed: () => PasswordLoaded(
+        passwords: [entryOne, entryTwo],
+        groupedEntries: const [],
+      ),
+      act: (testBloc) => testBloc.add(const DeletePassword('2')),
+      expect: () => [
+        loadedStateWith(
+          passwords: [entryOne],
+          groupedCount: 1,
+          groupedMemberTotal: 1,
+        ),
+      ],
+    );
+
+    blocTest<PasswordBloc, PasswordState>(
+      'SearchPasswords filters grouped rows using grouped pipeline',
+      build: () {
+        when(
+          () => mockGetPasswords(),
+        ).thenAnswer((_) async => Success([entryOne, entryTwo]));
+        return bloc;
+      },
+      act: (testBloc) async {
+        testBloc.add(const LoadPasswords());
+        await Future<void>.delayed(Duration.zero);
+        testBloc.add(const SearchPasswords('first@example.com'));
+      },
+      expect: () => [
+        const PasswordLoading(),
+        loadedStateWith(
+          passwords: [entryOne, entryTwo],
+          groupedCount: 1,
+          groupedMemberTotal: 2,
+        ),
+        isA<PasswordLoaded>()
+            .having((state) => state.groupedEntries.length, 'group count', 1)
+            .having(
+              (state) => state.groupedEntries.single.members.length,
+              'member count',
+              1,
+            )
+            .having(
+              (state) => state.searchQuery,
+              'search query',
+              'first@example.com',
+            ),
+      ],
+    );
+
+    blocTest<PasswordBloc, PasswordState>(
+      'FilterPasswords applies favorites filter to grouped members',
+      build: () {
+        when(
+          () => mockGetPasswords(),
+        ).thenAnswer((_) async => Success([entryOne, entryTwo]));
+        return bloc;
+      },
+      act: (testBloc) async {
+        testBloc.add(const LoadPasswords());
+        await Future<void>.delayed(Duration.zero);
+        testBloc.add(const FilterPasswords(favoritesOnly: true));
+      },
+      expect: () => [
+        const PasswordLoading(),
+        loadedStateWith(
+          passwords: [entryOne, entryTwo],
+          groupedCount: 1,
+          groupedMemberTotal: 2,
+        ),
+        isA<PasswordLoaded>()
+            .having(
+              (state) => state.groupedEntries.single.members.length,
+              'favorite members',
+              1,
+            )
+            .having((state) => state.favoritesOnly, 'favoritesOnly', true),
+      ],
+    );
+
+    blocTest<PasswordBloc, PasswordState>(
+      'AddPassword falls back to LoadPasswords when state is not loaded',
+      build: () {
+        when(
+          () => mockSavePassword(any()),
+        ).thenAnswer((_) async => const Success(null));
+        when(
+          () => mockGetPasswords(),
+        ).thenAnswer((_) async => Success([entryOne]));
+        return bloc;
+      },
+      act: (testBloc) => testBloc.add(AddPassword(entryOne)),
+      expect: () => [
+        const PasswordLoading(),
+        loadedStateWith(
+          passwords: [entryOne],
+          groupedCount: 1,
+          groupedMemberTotal: 1,
+        ),
+      ],
+    );
+
+    blocTest<PasswordBloc, PasswordState>(
+      'UpdatePassword falls back to LoadPasswords when state is not loaded',
+      build: () {
+        when(
+          () => mockSavePassword(any()),
+        ).thenAnswer((_) async => const Success(null));
+        when(
+          () => mockGetPasswords(),
+        ).thenAnswer((_) async => Success([entryOne]));
+        return bloc;
+      },
+      act: (testBloc) => testBloc.add(UpdatePassword(entryOne)),
+      expect: () => [
+        const PasswordLoading(),
+        loadedStateWith(
+          passwords: [entryOne],
+          groupedCount: 1,
+          groupedMemberTotal: 1,
+        ),
+      ],
+    );
+
+    blocTest<PasswordBloc, PasswordState>(
+      'DeletePassword falls back to LoadPasswords when state is not loaded',
+      build: () {
+        when(
+          () => mockDeletePassword(any()),
+        ).thenAnswer((_) async => const Success(null));
+        when(
+          () => mockGetPasswords(),
+        ).thenAnswer((_) async => Success([entryOne]));
+        return bloc;
+      },
+      act: (testBloc) => testBloc.add(const DeletePassword('1')),
+      expect: () => [
+        const PasswordLoading(),
+        loadedStateWith(
+          passwords: [entryOne],
+          groupedCount: 1,
+          groupedMemberTotal: 1,
+        ),
+      ],
+    );
+
+    test('listens to dataChanges stream and reloads grouped entries', () async {
+      final controller = StreamController<void>();
+      when(
+        () => mockRepository.dataChanges,
+      ).thenAnswer((_) => controller.stream);
+      when(
+        () => mockGetPasswords(),
+      ).thenAnswer((_) async => Success([entryOne]));
+
+      final testBloc = PasswordBloc(
+        mockGetPasswords,
+        mockSavePassword,
+        mockDeletePassword,
+        mockRepository,
       );
 
-      blocTest<PasswordBloc, PasswordState>(
-        'on UpdatePassword should reload if state is not PasswordLoaded',
-        build: () {
-          when(
-            () => mockSavePassword(any()),
-          ).thenAnswer((_) async => const Success(null));
-          when(
-            () => mockGetPasswords(),
-          ).thenAnswer((_) async => Success([tEntry]));
-          return bloc;
-        },
-        act: (bloc) => bloc.add(UpdatePassword(tEntry)),
-        expect: () => [
-          const PasswordLoading(),
-          PasswordLoaded([tEntry]),
-        ],
-      );
+      controller.add(null);
+      await Future<void>.delayed(Duration.zero);
 
-      blocTest<PasswordBloc, PasswordState>(
-        'on DeletePassword should reload if state is not PasswordLoaded',
-        build: () {
-          when(
-            () => mockDeletePassword(any()),
-          ).thenAnswer((_) async => const Success(null));
-          when(
-            () => mockGetPasswords(),
-          ).thenAnswer((_) async => Success([tEntry]));
-          return bloc;
-        },
-        act: (bloc) => bloc.add(const DeletePassword('1')),
-        expect: () => [
-          const PasswordLoading(),
-          PasswordLoaded([tEntry]),
-        ],
-      );
-
-      blocTest<PasswordBloc, PasswordState>(
-        'on AddPassword emits PasswordError on failure',
-        build: () {
-          when(
-            () => mockSavePassword(any()),
-          ).thenAnswer((_) async => const Error(DatabaseFailure('fail')));
-          return bloc;
-        },
-        act: (bloc) => bloc.add(AddPassword(tEntry)),
-        expect: () => [const PasswordError('fail')],
-      );
-
-      blocTest<PasswordBloc, PasswordState>(
-        'on UpdatePassword emits PasswordError on failure',
-        build: () {
-          when(
-            () => mockSavePassword(any()),
-          ).thenAnswer((_) async => const Error(DatabaseFailure('fail')));
-          return bloc;
-        },
-        act: (bloc) => bloc.add(UpdatePassword(tEntry)),
-        expect: () => [const PasswordError('fail')],
-      );
-
-      blocTest<PasswordBloc, PasswordState>(
-        'on DeletePassword emits PasswordError on failure',
-        build: () {
-          when(
-            () => mockDeletePassword(any()),
-          ).thenAnswer((_) async => const Error(DatabaseFailure('fail')));
-          return bloc;
-        },
-        act: (bloc) => bloc.add(const DeletePassword('1')),
-        expect: () => [const PasswordError('fail')],
-      );
+      verify(() => mockGetPasswords()).called(1);
+      await testBloc.close();
+      await controller.close();
     });
 
-    group('External Data Changes & Close', () {
-      test(
-        'listens to repository dataChanges and fires LoadPasswords',
-        () async {
-          final controller = StreamController<void>();
-          when(
-            () => mockRepository.dataChanges,
-          ).thenAnswer((_) => controller.stream);
-          when(
-            () => mockGetPasswords(),
-          ).thenAnswer((_) async => Success([tEntry]));
-
-          final testBloc = PasswordBloc(
-            mockGetPasswords,
-            mockSavePassword,
-            mockDeletePassword,
-            mockRepository,
-          );
-
-          controller.add(null);
-          await Future.delayed(Duration.zero);
-
-          verify(() => mockGetPasswords()).called(1);
-          await testBloc.close();
-          await controller.close();
-        },
-      );
-
-      test('close() cleans up subscriptions properly', () async {
-        final b = PasswordBloc(
-          mockGetPasswords,
-          mockSavePassword,
-          mockDeletePassword,
-          mockRepository,
-        );
-        await b.close();
-        expect(b.state, isA<PasswordState>());
-      });
-    });
-
-    group('PasswordEvent props', () {
-      test('props are correct', () {
-        expect(const LoadPasswords().props, isEmpty);
-        expect(AddPassword(tEntry).props, [tEntry]);
-        expect(UpdatePassword(tEntry).props, [tEntry]);
-        expect(const DeletePassword('1').props, ['1']);
-      });
+    test('PasswordEvent props include grouped events', () {
+      expect(const LoadPasswords().props, isEmpty);
+      expect(const SearchPasswords('query').props, ['query']);
+      expect(const FilterPasswords(folder: 'work', favoritesOnly: true).props, [
+        'work',
+        true,
+      ]);
+      expect(const ClearPasswordFilters().props, isEmpty);
+      expect(AddPassword(entryOne).props, [entryOne]);
+      expect(UpdatePassword(entryOne).props, [entryOne]);
+      expect(const DeletePassword('1').props, ['1']);
     });
   });
 }

--- a/test/features/home/presentation/home_screen_test.dart
+++ b/test/features/home/presentation/home_screen_test.dart
@@ -103,5 +103,31 @@ void main() {
         ),
       ).called(1);
     });
+
+    testWidgets(
+      'navigates to edit password when single-account group is tapped',
+      (tester) async {
+        when(
+          () => mockGoRouter.push(any(), extra: any(named: 'extra')),
+        ).thenAnswer((_) async => null);
+        await loadHomeScreen(
+          tester,
+          PasswordLoaded(
+            passwords: PasswordFixtures.list,
+            groupedEntries: groupedEntries,
+          ),
+        );
+
+        await tester.tap(find.text(groupedEntries[1].displayName));
+        await tester.pumpAndSettle();
+
+        verify(
+          () => mockGoRouter.push(
+            AppRoutes.editPassword,
+            extra: groupedEntries[1].members.first,
+          ),
+        ).called(1);
+      },
+    );
   });
 }

--- a/test/features/home/presentation/home_screen_test.dart
+++ b/test/features/home/presentation/home_screen_test.dart
@@ -1,5 +1,9 @@
+import 'package:go_router/go_router.dart';
+import 'package:passvault/config/routes/app_routes.dart';
+import 'package:passvault/features/home/domain/entities/grouped_home_entry.dart';
 import 'package:passvault/features/home/presentation/bloc/password/password_bloc.dart';
 import 'package:passvault/features/home/presentation/home_screen.dart';
+import 'package:passvault/features/home/presentation/widgets/grouped_password_list_tile.dart';
 
 import '../../../fixtures/password_fixtures.dart';
 import '../../../helpers/test_helpers.dart';
@@ -10,13 +14,33 @@ class MockPasswordBloc extends Mock implements PasswordBloc {
   Stream<PasswordState> get stream => Stream.value(state);
 }
 
+class MockGoRouter extends Mock implements GoRouter {}
+
 void main() {
   late MockPasswordBloc mockPasswordBloc;
+  late MockGoRouter mockGoRouter;
   late HomeRobot robot;
+  late List<GroupedHomeEntry> groupedEntries;
 
   setUp(() {
     mockPasswordBloc = MockPasswordBloc();
+    mockGoRouter = MockGoRouter();
     when(() => mockPasswordBloc.close()).thenAnswer((_) async {});
+    groupedEntries = [
+      GroupedHomeEntry(
+        canonicalKey: 'google.com',
+        displayName: 'google.com',
+        members: [
+          PasswordFixtures.google,
+          PasswordFixtures.google.copyWith(id: 'google-2'),
+        ],
+      ),
+      GroupedHomeEntry(
+        canonicalKey: 'facebook.com',
+        displayName: 'facebook.com',
+        members: [PasswordFixtures.facebook],
+      ),
+    ];
   });
 
   Future<void> loadHomeScreen(
@@ -33,26 +57,51 @@ void main() {
     when(() => mockPasswordBloc.state).thenReturn(state);
 
     await tester.pumpApp(
-      BlocProvider<PasswordBloc>.value(
-        value: mockPasswordBloc,
-        child: const HomeScreen(),
+      InheritedGoRouter(
+        goRouter: mockGoRouter,
+        child: BlocProvider<PasswordBloc>.value(
+          value: mockPasswordBloc,
+          child: const HomeScreen(),
+        ),
       ),
       usePumpAndSettle: usePumpAndSettle,
     );
   }
 
   group('$HomeScreen', () {
-    testWidgets('renders password list when data is loaded', (tester) async {
-      final passwords = PasswordFixtures.list;
+    testWidgets('renders grouped list when data is loaded', (tester) async {
       await loadHomeScreen(
         tester,
-        PasswordLoaded(passwords: passwords, groupedEntries: const []),
+        PasswordLoaded(
+          passwords: PasswordFixtures.list,
+          groupedEntries: groupedEntries,
+        ),
       );
 
       robot.expectPasswordListVisible();
-      robot.expectPasswordVisible('Google');
-      robot.expectPasswordVisible('Facebook');
-      robot.expectPasswordsCount(3);
+      expect(find.byType(GroupedPasswordListTile), findsNWidgets(2));
+    });
+
+    testWidgets('navigates to grouped details when group is tapped', (
+      tester,
+    ) async {
+      when(() => mockGoRouter.push(any())).thenAnswer((_) async => null);
+      await loadHomeScreen(
+        tester,
+        PasswordLoaded(
+          passwords: PasswordFixtures.list,
+          groupedEntries: groupedEntries,
+        ),
+      );
+
+      await tester.tap(find.text(groupedEntries.first.displayName));
+      await tester.pumpAndSettle();
+
+      verify(
+        () => mockGoRouter.push(
+          AppRoutes.groupedPasswordDetailsPath('google.com'),
+        ),
+      ).called(1);
     });
   });
 }

--- a/test/features/home/presentation/home_screen_test.dart
+++ b/test/features/home/presentation/home_screen_test.dart
@@ -44,7 +44,10 @@ void main() {
   group('$HomeScreen', () {
     testWidgets('renders password list when data is loaded', (tester) async {
       final passwords = PasswordFixtures.list;
-      await loadHomeScreen(tester, PasswordLoaded(passwords));
+      await loadHomeScreen(
+        tester,
+        PasswordLoaded(passwords: passwords, groupedEntries: const []),
+      );
 
       robot.expectPasswordListVisible();
       robot.expectPasswordVisible('Google');

--- a/test/features/home/presentation/screens/grouped_password_details_screen_test.dart
+++ b/test/features/home/presentation/screens/grouped_password_details_screen_test.dart
@@ -1,0 +1,129 @@
+import 'package:go_router/go_router.dart';
+import 'package:passvault/config/routes/app_routes.dart';
+import 'package:passvault/features/home/domain/entities/grouped_home_entry.dart';
+import 'package:passvault/features/home/presentation/bloc/password/password_bloc.dart';
+import 'package:passvault/features/home/presentation/screens/grouped_password_details_screen.dart';
+import 'package:passvault/features/home/presentation/widgets/password_list_tile.dart';
+
+import '../../../../fixtures/password_fixtures.dart';
+import '../../../../helpers/test_helpers.dart';
+
+class MockPasswordBloc extends Mock implements PasswordBloc {
+  @override
+  Stream<PasswordState> get stream => Stream.value(state);
+}
+
+class MockGoRouter extends Mock implements GoRouter {}
+
+void main() {
+  late MockPasswordBloc mockPasswordBloc;
+  late MockGoRouter mockGoRouter;
+  late List<GroupedHomeEntry> groupedEntries;
+  late AppLocalizations l10n;
+
+  setUpAll(() async {
+    l10n = await getL10n();
+  });
+
+  setUp(() {
+    mockPasswordBloc = MockPasswordBloc();
+    mockGoRouter = MockGoRouter();
+    when(() => mockPasswordBloc.close()).thenAnswer((_) async {});
+    groupedEntries = [
+      GroupedHomeEntry(
+        canonicalKey: 'google.com',
+        displayName: 'google.com',
+        members: [
+          PasswordFixtures.google,
+          PasswordFixtures.google.copyWith(
+            id: 'google-2',
+            username: 'user2@gmail.com',
+          ),
+        ],
+      ),
+    ];
+  });
+
+  Future<void> loadScreen(
+    WidgetTester tester, {
+    required PasswordState state,
+    required String groupKey,
+  }) async {
+    when(() => mockPasswordBloc.state).thenReturn(state);
+
+    await tester.pumpApp(
+      InheritedGoRouter(
+        goRouter: mockGoRouter,
+        child: BlocProvider<PasswordBloc>.value(
+          value: mockPasswordBloc,
+          child: GroupedPasswordDetailsScreen(groupKey: groupKey),
+        ),
+      ),
+    );
+  }
+
+  group('$GroupedPasswordDetailsScreen', () {
+    testWidgets('renders all members for the selected group', (tester) async {
+      await loadScreen(
+        tester,
+        state: PasswordLoaded(
+          passwords: PasswordFixtures.list,
+          groupedEntries: groupedEntries,
+        ),
+        groupKey: 'google.com',
+      );
+
+      expect(
+        find.byKey(const Key('grouped_details_member_list')),
+        findsOneWidget,
+      );
+      expect(find.byType(PasswordListTile), findsNWidgets(2));
+      expect(find.text(l10n.groupedCredentialCount(2)), findsOneWidget);
+    });
+
+    testWidgets('shows not-found state when group is unavailable', (
+      tester,
+    ) async {
+      await loadScreen(
+        tester,
+        state: PasswordLoaded(
+          passwords: PasswordFixtures.list,
+          groupedEntries: const [],
+        ),
+        groupKey: 'missing.com',
+      );
+
+      expect(
+        find.byKey(const Key('grouped_details_not_found_text')),
+        findsOneWidget,
+      );
+      expect(find.text(l10n.groupedEntryNotFound), findsOneWidget);
+    });
+
+    testWidgets('keeps existing account edit action in grouped details', (
+      tester,
+    ) async {
+      when(
+        () => mockGoRouter.push(any(), extra: any(named: 'extra')),
+      ).thenAnswer((_) async => null);
+      await loadScreen(
+        tester,
+        state: PasswordLoaded(
+          passwords: PasswordFixtures.list,
+          groupedEntries: groupedEntries,
+        ),
+        groupKey: 'google.com',
+      );
+
+      await tester.tap(find.text(PasswordFixtures.google.appName).first);
+      await tester.pumpAndSettle();
+
+      verify(
+        () => mockGoRouter.push(
+          AppRoutes.editPassword,
+          extra: PasswordFixtures.google,
+        ),
+      ).called(1);
+    });
+  });
+}

--- a/test/features/home/presentation/widgets/grouped_password_list_tile_test.dart
+++ b/test/features/home/presentation/widgets/grouped_password_list_tile_test.dart
@@ -1,0 +1,79 @@
+import 'package:passvault/features/home/domain/entities/grouped_home_entry.dart';
+import 'package:passvault/features/home/presentation/widgets/grouped_password_list_tile.dart';
+
+import '../../../../fixtures/password_fixtures.dart';
+import '../../../../helpers/test_helpers.dart';
+
+class MockCallback extends Mock {
+  void call();
+}
+
+void main() {
+  late GroupedHomeEntry multiEntryGroup;
+  late GroupedHomeEntry singleEntryGroup;
+  late AppLocalizations l10n;
+
+  setUpAll(() async {
+    l10n = await getL10n();
+  });
+
+  setUp(() {
+    multiEntryGroup = GroupedHomeEntry(
+      canonicalKey: 'google.com',
+      displayName: 'google.com',
+      members: [
+        PasswordFixtures.google,
+        PasswordFixtures.google.copyWith(id: 'google-2'),
+      ],
+    );
+    singleEntryGroup = GroupedHomeEntry(
+      canonicalKey: 'facebook.com',
+      displayName: 'facebook.com',
+      members: [PasswordFixtures.facebook],
+    );
+  });
+
+  group('$GroupedPasswordListTile', () {
+    testWidgets(
+      'shows count badge only when account count is greater than one',
+      (tester) async {
+        await tester.pumpApp(
+          GroupedPasswordListTile(group: multiEntryGroup, onTap: () {}),
+        );
+
+        expect(find.text(l10n.groupedCredentialCount(2)), findsOneWidget);
+        expect(
+          find.byKey(const Key('grouped_password_count_badge')),
+          findsOneWidget,
+        );
+
+        await tester.pumpApp(
+          GroupedPasswordListTile(group: singleEntryGroup, onTap: () {}),
+        );
+
+        expect(find.text(l10n.groupedCredentialCount(1)), findsOneWidget);
+        expect(
+          find.byKey(const Key('grouped_password_count_badge')),
+          findsNothing,
+        );
+      },
+    );
+
+    testWidgets('calls onTap when tapped', (tester) async {
+      final onTap = MockCallback();
+
+      await tester.pumpApp(
+        GroupedPasswordListTile(group: multiEntryGroup, onTap: onTap.call),
+      );
+
+      await tester.tap(
+        find.byKey(
+          Key('grouped_password_tile_${multiEntryGroup.canonicalKey}'),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      verify(() => onTap()).called(1);
+    });
+  });
+}

--- a/test/features/home/presentation/widgets/grouped_password_list_tile_test.dart
+++ b/test/features/home/presentation/widgets/grouped_password_list_tile_test.dart
@@ -42,10 +42,6 @@ void main() {
         );
 
         expect(find.text(l10n.groupedCredentialCount(2)), findsOneWidget);
-        expect(
-          find.byKey(const Key('grouped_password_count_badge')),
-          findsOneWidget,
-        );
 
         await tester.pumpApp(
           GroupedPasswordListTile(group: singleEntryGroup, onTap: () {}),
@@ -54,10 +50,6 @@ void main() {
         expect(find.text(l10n.groupedCredentialCount(1)), findsNothing);
         expect(
           find.text(singleEntryGroup.members.first.username),
-          findsNothing,
-        );
-        expect(
-          find.byKey(const Key('grouped_password_count_badge')),
           findsNothing,
         );
       },

--- a/test/features/home/presentation/widgets/grouped_password_list_tile_test.dart
+++ b/test/features/home/presentation/widgets/grouped_password_list_tile_test.dart
@@ -51,7 +51,11 @@ void main() {
           GroupedPasswordListTile(group: singleEntryGroup, onTap: () {}),
         );
 
-        expect(find.text(l10n.groupedCredentialCount(1)), findsOneWidget);
+        expect(find.text(l10n.groupedCredentialCount(1)), findsNothing);
+        expect(
+          find.text(singleEntryGroup.members.first.username),
+          findsNothing,
+        );
         expect(
           find.byKey(const Key('grouped_password_count_badge')),
           findsNothing,


### PR DESCRIPTION
Implementation of unconditional registrable domain grouping for credentials.

Closes #42.

### Changes
- Removed hybrid subdomain allowlists in favor of unconditional `_registrableDomain` extraction.
- Removed hardcoded Android package overrides (`_androidDisplayNameOverrides`).
- Updated validation suites with 10 exhaustive scenarios.

<!-- COVERAGE_START -->
## 📊 Code Coverage Report
| Metric | Value |
| :--- | :--- |
| **Total Lines** | 5291 |
| **Lines Hit** | 4320 |
| **Overall Coverage** | **81.65%** |

_Generated by PassVault CI_
<!-- COVERAGE_END -->
