### PR TITLE
feat(import-export): support user-created strategy backup and restore

### DIFF
--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -279,17 +279,6 @@ extension GetItInjectableX on _i174.GetIt {
         gh<_i360.GetBiometricsEnabledUseCase>(),
       ),
     );
-    gh.lazySingleton<_i454.ImportExportBloc>(
-      () => _i454.ImportExportBloc(
-        gh<_i823.ImportPasswordsUseCase>(),
-        gh<_i649.ResolveDuplicatesUseCase>(),
-        gh<_i766.ClearAllPasswordsUseCase>(),
-        gh<_i580.PasswordRepository>(),
-        gh<_i636.DataService>(),
-        gh<_i367.FileService>(),
-        gh<_i108.IFilePickerService>(),
-      ),
-    );
     gh.lazySingleton<_i847.PasswordBloc>(
       () => _i847.PasswordBloc(
         gh<_i969.GetPasswordsUseCase>(),
@@ -322,6 +311,19 @@ extension GetItInjectableX on _i174.GetIt {
         gh<_i16.GeneratePasswordUseCase>(),
         gh<_i371.EstimatePasswordStrengthUseCase>(),
         gh<_i739.GetPasswordGenerationSettingsUseCase>(),
+      ),
+    );
+    gh.lazySingleton<_i454.ImportExportBloc>(
+      () => _i454.ImportExportBloc(
+        gh<_i823.ImportPasswordsUseCase>(),
+        gh<_i649.ResolveDuplicatesUseCase>(),
+        gh<_i766.ClearAllPasswordsUseCase>(),
+        gh<_i580.PasswordRepository>(),
+        gh<_i636.DataService>(),
+        gh<_i367.FileService>(),
+        gh<_i108.IFilePickerService>(),
+        gh<_i739.GetPasswordGenerationSettingsUseCase>(),
+        gh<_i739.SavePasswordGenerationSettingsUseCase>(),
       ),
     );
     return this;

--- a/lib/core/services/data_service.dart
+++ b/lib/core/services/data_service.dart
@@ -7,6 +7,7 @@ import 'package:injectable/injectable.dart';
 import 'package:passvault/core/services/crypto_service.dart';
 import 'package:passvault/core/services/helpers/csv_import_helper.dart';
 import 'package:passvault/features/password_manager/domain/entities/password_entry.dart';
+import 'package:passvault/features/settings/domain/entities/password_generation_settings.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:share_plus/share_plus.dart';
 
@@ -35,10 +36,21 @@ class DataService {
     );
   }
 
-  /// Generates JSON string from entries.
-  String generateJson(List<PasswordEntry> entries) {
-    final jsonList = entries.map((e) => e.toJson()).toList();
-    return jsonEncode(jsonList);
+  /// Generates JSON string from entries and optional strategies.
+  String generateJson(
+    List<PasswordEntry> entries, {
+    List<PasswordGenerationStrategy>? strategies,
+  }) {
+    if (strategies == null || strategies.isEmpty) {
+      final jsonList = entries.map((e) => e.toJson()).toList();
+      return jsonEncode(jsonList);
+    }
+
+    final payload = {
+      'passwords': entries.map((e) => e.toJson()).toList(),
+      'strategies': strategies.map((e) => e.toJson()).toList(),
+    };
+    return jsonEncode(payload);
   }
 
   /// Exports password entries as a CSV file using system share.
@@ -99,24 +111,55 @@ class DataService {
     );
   }
 
-  /// Generates encrypted bytes from entries.
+  /// Generates encrypted bytes from entries and optional strategies.
   Uint8List generateEncryptedJson(
     List<PasswordEntry> entries,
-    String password,
-  ) {
-    final jsonString = generateJson(entries);
+    String password, {
+    List<PasswordGenerationStrategy>? strategies,
+  }) {
+    final jsonString = generateJson(entries, strategies: strategies);
     return _cryptoService.encryptWithPassword(
       Uint8List.fromList(utf8.encode(jsonString)),
       password,
     );
   }
 
-  /// Imports password entries from a JSON string.
-  List<PasswordEntry> importFromJson(String jsonContent) {
-    final List<dynamic> decoded = jsonDecode(jsonContent);
-    return decoded
-        .map((item) => PasswordEntry.fromJson(item as Map<String, dynamic>))
-        .toList();
+  /// Imports password entries and strategies from a JSON string.
+  ({List<PasswordEntry> passwords, List<PasswordGenerationStrategy> strategies})
+  importFromJson(String jsonContent) {
+    final decoded = jsonDecode(jsonContent);
+    if (decoded is List) {
+      final passwords = decoded
+          .map((item) => PasswordEntry.fromJson(item as Map<String, dynamic>))
+          .toList();
+      return (
+        passwords: passwords,
+        strategies: const <PasswordGenerationStrategy>[],
+      );
+    } else if (decoded is Map) {
+      final passwordsList = decoded['passwords'] as List<dynamic>? ?? [];
+      final strategiesList = decoded['strategies'] as List<dynamic>? ?? [];
+
+      final passwords = passwordsList
+          .map(
+            (item) =>
+                PasswordEntry.fromJson(Map<String, dynamic>.from(item as Map)),
+          )
+          .toList();
+      final strategies = strategiesList
+          .map(
+            (item) => PasswordGenerationStrategy.fromJson(
+              Map<String, dynamic>.from(item as Map),
+            ),
+          )
+          .toList();
+
+      return (passwords: passwords, strategies: strategies);
+    }
+    return (
+      passwords: const <PasswordEntry>[],
+      strategies: const <PasswordGenerationStrategy>[],
+    );
   }
 
   /// Imports password entries from a CSV string.
@@ -124,14 +167,12 @@ class DataService {
     return CsvImportHelper.parse(csvContent);
   }
 
-  /// Imports password entries from an encrypted `.pvault` file.
+  /// Imports password entries and strategies from an encrypted `.pvault` file.
   ///
   /// Requires the same password used during export.
   /// Throws [StateError] if the password is incorrect.
-  List<PasswordEntry> importFromEncrypted(
-    Uint8List encryptedData,
-    String password,
-  ) {
+  ({List<PasswordEntry> passwords, List<PasswordGenerationStrategy> strategies})
+  importFromEncrypted(Uint8List encryptedData, String password) {
     final decrypted = _cryptoService.decryptWithPassword(
       encryptedData,
       password,

--- a/lib/features/password_manager/presentation/bloc/import_export/import_export_bloc.dart
+++ b/lib/features/password_manager/presentation/bloc/import_export/import_export_bloc.dart
@@ -14,6 +14,8 @@ import 'package:passvault/features/password_manager/domain/usecases/import_passw
 import 'package:passvault/features/password_manager/domain/usecases/resolve_duplicates_usecase.dart';
 import 'package:passvault/features/password_manager/presentation/bloc/import_export/import_export_helpers.dart';
 import 'package:passvault/features/password_manager/presentation/bloc/import_export/import_export_path_resolver.dart';
+import 'package:passvault/features/settings/domain/entities/password_generation_settings.dart';
+import 'package:passvault/features/settings/domain/usecases/password_settings_usecases.dart';
 
 part 'import_export_event.dart';
 part 'import_export_state.dart';
@@ -27,6 +29,10 @@ class ImportExportBloc extends Bloc<ImportExportEvent, ImportExportState> {
   final DataService _dataService;
   final FileService _fileService;
   final IFilePickerService _filePickerService;
+  final GetPasswordGenerationSettingsUseCase
+  _getPasswordGenerationSettingsUseCase;
+  final SavePasswordGenerationSettingsUseCase
+  _savePasswordGenerationSettingsUseCase;
 
   ImportExportBloc(
     this._importPasswordsUseCase,
@@ -36,6 +42,8 @@ class ImportExportBloc extends Bloc<ImportExportEvent, ImportExportState> {
     this._dataService,
     this._fileService,
     this._filePickerService,
+    this._getPasswordGenerationSettingsUseCase,
+    this._savePasswordGenerationSettingsUseCase,
   ) : super(const ImportExportInitial()) {
     on<ExportDataEvent>(_onExportData);
     on<ExportEncryptedEvent>(_onExportEncrypted);
@@ -73,8 +81,15 @@ class ImportExportBloc extends Bloc<ImportExportEvent, ImportExportState> {
             'passvault_export',
             extension,
           );
+
+          final settingsResult = _getPasswordGenerationSettingsUseCase();
+          final strategies = settingsResult.fold(
+            (failure) => <PasswordGenerationStrategy>[],
+            (settings) => settings.strategies,
+          );
+
           final content = event.isJson
-              ? _dataService.generateJson(passwords)
+              ? _dataService.generateJson(passwords, strategies: strategies)
               : _dataService.generateCsv(passwords);
 
           await _saveAndEmit(fileName, utf8.encode(content), [extension], emit);
@@ -108,9 +123,17 @@ class ImportExportBloc extends Bloc<ImportExportEvent, ImportExportState> {
           }
 
           final fileName = generateExportFileName('passvault_export', 'pvault');
+
+          final settingsResult = _getPasswordGenerationSettingsUseCase();
+          final strategies = settingsResult.fold(
+            (failure) => <PasswordGenerationStrategy>[],
+            (settings) => settings.strategies,
+          );
+
           final content = _dataService.generateEncryptedJson(
             passwords,
             event.password,
+            strategies: strategies,
           );
 
           await _saveAndEmit(fileName, content, ['pvault'], emit);
@@ -164,6 +187,57 @@ class ImportExportBloc extends Bloc<ImportExportEvent, ImportExportState> {
     }
   }
 
+  Future<void> _importStrategies(
+    List<PasswordGenerationStrategy>? importedStrategies,
+  ) async {
+    if (importedStrategies == null || importedStrategies.isEmpty) return;
+
+    final currentSettingsResult = _getPasswordGenerationSettingsUseCase();
+    await currentSettingsResult.fold((failure) async {}, (
+      currentSettings,
+    ) async {
+      final currentStrategies = List<PasswordGenerationStrategy>.from(
+        currentSettings.strategies,
+      );
+      final defaultStrategyIds = {'default-strategy', 'memorable-strategy'};
+
+      for (final imported in importedStrategies) {
+        // 1. Skip importing predefined default/memorable strategies.
+        if (defaultStrategyIds.contains(imported.id) ||
+            imported.name.toLowerCase() == 'default' ||
+            imported.name.toLowerCase() == 'memorable') {
+          continue;
+        }
+
+        // 2. Overwrite custom strategy if ID matches.
+        final existingByIdIndex = currentStrategies.indexWhere(
+          (s) => s.id == imported.id,
+        );
+
+        if (existingByIdIndex != -1) {
+          currentStrategies[existingByIdIndex] = imported;
+        } else {
+          // 3. Resolve name collisions.
+          var strategyToInsert = imported;
+          final hasSameName = currentStrategies.any(
+            (s) => s.name.toLowerCase() == imported.name.toLowerCase(),
+          );
+          if (hasSameName) {
+            strategyToInsert = imported.copyWith(
+              name: '${imported.name} (Imported)',
+            );
+          }
+          currentStrategies.add(strategyToInsert);
+        }
+      }
+
+      final newSettings = currentSettings.copyWith(
+        strategies: currentStrategies,
+      );
+      await _savePasswordGenerationSettingsUseCase(newSettings);
+    });
+  }
+
   Future<void> _resolveAndImport(
     String path,
     Emitter<ImportExportState> emit, {
@@ -173,7 +247,8 @@ class ImportExportBloc extends Bloc<ImportExportEvent, ImportExportState> {
     final result = await resolver.resolve(path, password: password);
 
     switch (result) {
-      case ImportPathEntries(:final entries):
+      case ImportPathEntries(:final entries, :final strategies):
+        await _importStrategies(strategies);
         emit(
           await resolveImportState(
             importPasswordsUseCase: _importPasswordsUseCase,

--- a/lib/features/password_manager/presentation/bloc/import_export/import_export_path_resolver.dart
+++ b/lib/features/password_manager/presentation/bloc/import_export/import_export_path_resolver.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 import 'package:passvault/core/services/data_service.dart';
 import 'package:passvault/core/services/file_service.dart';
 import 'package:passvault/features/password_manager/domain/entities/password_entry.dart';
+import 'package:passvault/features/settings/domain/entities/password_generation_settings.dart';
 
 sealed class ImportPathResult {
   const ImportPathResult();
@@ -10,7 +11,8 @@ sealed class ImportPathResult {
 
 final class ImportPathEntries extends ImportPathResult {
   final List<PasswordEntry> entries;
-  const ImportPathEntries(this.entries);
+  final List<PasswordGenerationStrategy>? strategies;
+  const ImportPathEntries(this.entries, {this.strategies});
 }
 
 final class ImportPathRequiresPassword extends ImportPathResult {
@@ -31,12 +33,16 @@ class ImportExportPathResolver {
   Future<ImportPathResult> resolve(String path, {String? password}) async {
     if (_isJson(path)) {
       final content = await _fileService.readAsString(path);
-      return ImportPathEntries(_dataService.importFromJson(content));
+      final result = _dataService.importFromJson(content);
+      return ImportPathEntries(result.passwords, strategies: result.strategies);
     }
 
     if (_isCsv(path)) {
       final content = await _fileService.readAsString(path);
-      return ImportPathEntries(_dataService.importFromCsv(content));
+      return ImportPathEntries(
+        _dataService.importFromCsv(content),
+        strategies: const [],
+      );
     }
 
     if (_isEncryptedBackup(path)) {
@@ -44,12 +50,11 @@ class ImportExportPathResolver {
         return ImportPathRequiresPassword(path);
       }
       final encryptedData = await _fileService.readAsBytes(path);
-      return ImportPathEntries(
-        _dataService.importFromEncrypted(
-          Uint8List.fromList(encryptedData),
-          password,
-        ),
+      final result = _dataService.importFromEncrypted(
+        Uint8List.fromList(encryptedData),
+        password,
       );
+      return ImportPathEntries(result.passwords, strategies: result.strategies);
     }
 
     return const ImportPathInvalidFormat();

--- a/lib/features/password_manager/presentation/export_vault_screen.dart
+++ b/lib/features/password_manager/presentation/export_vault_screen.dart
@@ -115,6 +115,33 @@ class _ExportVaultScreenState extends State<ExportVaultScreen> {
                       isSelected: !_isJsonSelected,
                       onTap: () => setState(() => _isJsonSelected = false),
                     ),
+                    if (!_isJsonSelected) ...[
+                      const SizedBox(height: AppSpacing.m),
+                      AppCard(
+                        key: const Key('export_csv_warning_card'),
+                        backgroundColor: theme.warning.withValues(alpha: 0.1),
+                        padding: const EdgeInsets.all(AppSpacing.m),
+                        child: Row(
+                          children: [
+                            Icon(
+                              LucideIcons.triangleAlert,
+                              color: theme.warning,
+                              size: 20,
+                            ),
+                            const SizedBox(width: AppSpacing.m),
+                            Expanded(
+                              child: Text(
+                                l10n.csvWarningNoStrategies,
+                                style: context.typography.bodySmall?.copyWith(
+                                  color: theme.warning,
+                                  fontWeight: FontWeight.w500,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
                     const SizedBox(height: AppSpacing.xl),
                     // Encryption Toggle
                     AppCard(

--- a/lib/features/settings/presentation/settings_screen.dart
+++ b/lib/features/settings/presentation/settings_screen.dart
@@ -34,10 +34,12 @@ class SettingsScreen extends StatelessWidget {
           ScaffoldMessenger.of(
             context,
           ).showSnackBar(SnackBar(content: Text(l10n.importSuccess)));
+          context.read<SettingsBloc>().add(const LoadSettings());
           context.read<ImportExportBloc>().add(const ResetMigrationStatus());
         } else if (state is DuplicatesDetected) {
           context.push(AppRoutes.resolveDuplicates, extra: state.duplicates);
         } else if (state is DuplicatesResolved) {
+          context.read<SettingsBloc>().add(const LoadSettings());
           context.read<ImportExportBloc>().add(const ResetMigrationStatus());
         } else if (state is ImportEncryptedFileSelected) {
           showDialog(

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -103,6 +103,7 @@
   "encryptionPassword": "Encryption Password",
   "exportNow": "Export Now",
   "warningSensitiveData": "Exported files contain your sensitive data. Keep them secure or delete them after use.",
+  "csvWarningNoStrategies": "CSV exports do not include custom generation strategies. Use JSON or Encrypted (.pvault) format to back up your strategies.",
   "passwordGenerator": "Password Generator",
   "lengthLabel": "Length",
   "uppercaseLabel": "Uppercase (A-Z)",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -670,6 +670,12 @@ abstract class AppLocalizations {
   /// **'Exported files contain your sensitive data. Keep them secure or delete them after use.'**
   String get warningSensitiveData;
 
+  /// No description provided for @csvWarningNoStrategies.
+  ///
+  /// In en, this message translates to:
+  /// **'CSV exports do not include custom generation strategies. Use JSON or Encrypted (.pvault) format to back up your strategies.'**
+  String get csvWarningNoStrategies;
+
   /// No description provided for @passwordGenerator.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -307,6 +307,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'Exported files contain your sensitive data. Keep them secure or delete them after use.';
 
   @override
+  String get csvWarningNoStrategies =>
+      'CSV exports do not include custom generation strategies. Use JSON or Encrypted (.pvault) format to back up your strategies.';
+
+  @override
   String get passwordGenerator => 'Password Generator';
 
   @override

--- a/test/core/services/data_service_test.dart
+++ b/test/core/services/data_service_test.dart
@@ -6,6 +6,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:passvault/core/services/crypto_service.dart';
 import 'package:passvault/core/services/data_service.dart';
 import 'package:passvault/features/password_manager/domain/entities/password_entry.dart';
+import 'package:passvault/features/settings/domain/entities/password_generation_settings.dart';
 
 class MockCryptoService extends Mock implements CryptoService {}
 
@@ -147,10 +148,52 @@ void main() {
         final json = dataService.generateJson(entries);
         final result = dataService.importFromJson(json);
 
-        expect(result.length, 1);
-        expect(result[0].appName, tEntry.appName);
-        expect(result[0].username, tEntry.username);
-        expect(result[0].password, tEntry.password);
+        expect(result.passwords.length, 1);
+        expect(result.passwords[0].appName, tEntry.appName);
+        expect(result.passwords[0].username, tEntry.username);
+        expect(result.passwords[0].password, tEntry.password);
+      });
+    });
+
+    group('Strategies Export/Import', () {
+      final tEntry = PasswordEntry(
+        id: '1',
+        appName: 'Test',
+        username: 'user',
+        password: 'pass',
+        lastUpdated: DateTime(2024, 1, 1),
+      );
+      final tStrategy = const PasswordGenerationStrategy(
+        id: 'strat-1',
+        name: 'My Custom Strategy',
+        length: 20,
+        useNumbers: true,
+        useSpecialChars: false,
+      );
+
+      test('should export and import both passwords and strategies', () {
+        final entries = [tEntry];
+        final strategies = [tStrategy];
+        final json = dataService.generateJson(entries, strategies: strategies);
+
+        final result = dataService.importFromJson(json);
+        expect(result.passwords.length, 1);
+        expect(result.passwords[0].appName, tEntry.appName);
+
+        expect(result.strategies.length, 1);
+        expect(result.strategies[0].name, 'My Custom Strategy');
+        expect(result.strategies[0].length, 20);
+        expect(result.strategies[0].useNumbers, true);
+        expect(result.strategies[0].useSpecialChars, false);
+      });
+
+      test('should remain backward compatible with legacy JSON list', () {
+        final legacyJson = jsonEncode([tEntry.toJson()]);
+        final result = dataService.importFromJson(legacyJson);
+
+        expect(result.passwords.length, 1);
+        expect(result.passwords[0].appName, tEntry.appName);
+        expect(result.strategies, isEmpty);
       });
     });
 
@@ -187,8 +230,8 @@ void main() {
           encrypted,
           tPassword,
         );
-        expect(resultDecrypted.length, 1);
-        expect(resultDecrypted[0].appName, 'Secure App');
+        expect(resultDecrypted.passwords.length, 1);
+        expect(resultDecrypted.passwords[0].appName, 'Secure App');
       });
     });
   });

--- a/test/features/password_manager/presentation/bloc/import_export/import_export_bloc_actions_and_props_test.dart
+++ b/test/features/password_manager/presentation/bloc/import_export/import_export_bloc_actions_and_props_test.dart
@@ -16,6 +16,8 @@ import 'package:passvault/features/password_manager/domain/usecases/clear_all_pa
 import 'package:passvault/features/password_manager/domain/usecases/import_passwords_usecase.dart';
 import 'package:passvault/features/password_manager/domain/usecases/resolve_duplicates_usecase.dart';
 import 'package:passvault/features/password_manager/presentation/bloc/import_export/import_export_bloc.dart';
+import 'package:passvault/features/settings/domain/entities/password_generation_settings.dart';
+import 'package:passvault/features/settings/domain/usecases/password_settings_usecases.dart';
 
 class MockBiometricService extends Mock implements BiometricService {}
 
@@ -36,6 +38,12 @@ class MockFileService extends Mock implements FileService {}
 
 class MockFilePickerService extends Mock implements IFilePickerService {}
 
+class MockGetPasswordGenerationSettingsUseCase extends Mock
+    implements GetPasswordGenerationSettingsUseCase {}
+
+class MockSavePasswordGenerationSettingsUseCase extends Mock
+    implements SavePasswordGenerationSettingsUseCase {}
+
 void main() {
   late ImportExportBloc bloc;
   late MockImportPasswordsUseCase mockImportUseCase;
@@ -46,6 +54,9 @@ void main() {
   late MockFileService mockFileService;
   late MockFilePickerService mockFilePickerService;
   late MockBiometricService mockBiometricService;
+  late MockGetPasswordGenerationSettingsUseCase mockGetPasswordSettingsUseCase;
+  late MockSavePasswordGenerationSettingsUseCase
+  mockSavePasswordSettingsUseCase;
 
   final testEntries = [
     PasswordEntry(
@@ -61,6 +72,7 @@ void main() {
     registerFallbackValue(<PasswordEntry>[]);
     registerFallbackValue(<DuplicatePasswordEntry>[]);
     registerFallbackValue(Uint8List(0));
+    registerFallbackValue(PasswordGenerationSettings.initial());
   });
 
   setUp(() {
@@ -72,12 +84,22 @@ void main() {
     mockFileService = MockFileService();
     mockFilePickerService = MockFilePickerService();
     mockBiometricService = MockBiometricService();
+    mockGetPasswordSettingsUseCase = MockGetPasswordGenerationSettingsUseCase();
+    mockSavePasswordSettingsUseCase =
+        MockSavePasswordGenerationSettingsUseCase();
 
     when(
       () => mockBiometricService.authenticate(
         localizedReason: any(named: 'localizedReason'),
       ),
     ).thenAnswer((_) async => true);
+
+    when(
+      () => mockGetPasswordSettingsUseCase(),
+    ).thenReturn(Success(PasswordGenerationSettings.initial()));
+    when(
+      () => mockSavePasswordSettingsUseCase(any()),
+    ).thenAnswer((_) async => const Success(null));
 
     bloc = ImportExportBloc(
       mockImportUseCase,
@@ -87,6 +109,8 @@ void main() {
       mockDataService,
       mockFileService,
       mockFilePickerService,
+      mockGetPasswordSettingsUseCase,
+      mockSavePasswordSettingsUseCase,
     );
   });
 

--- a/test/features/password_manager/presentation/bloc/import_export/import_export_bloc_test.dart
+++ b/test/features/password_manager/presentation/bloc/import_export/import_export_bloc_test.dart
@@ -16,6 +16,8 @@ import 'package:passvault/features/password_manager/domain/usecases/clear_all_pa
 import 'package:passvault/features/password_manager/domain/usecases/import_passwords_usecase.dart';
 import 'package:passvault/features/password_manager/domain/usecases/resolve_duplicates_usecase.dart';
 import 'package:passvault/features/password_manager/presentation/bloc/import_export/import_export_bloc.dart';
+import 'package:passvault/features/settings/domain/entities/password_generation_settings.dart';
+import 'package:passvault/features/settings/domain/usecases/password_settings_usecases.dart';
 
 class MockBiometricService extends Mock implements BiometricService {}
 
@@ -36,6 +38,12 @@ class MockFileService extends Mock implements FileService {}
 
 class MockFilePickerService extends Mock implements IFilePickerService {}
 
+class MockGetPasswordGenerationSettingsUseCase extends Mock
+    implements GetPasswordGenerationSettingsUseCase {}
+
+class MockSavePasswordGenerationSettingsUseCase extends Mock
+    implements SavePasswordGenerationSettingsUseCase {}
+
 void main() {
   late ImportExportBloc bloc;
   late MockImportPasswordsUseCase mockImportUseCase;
@@ -46,6 +54,9 @@ void main() {
   late MockFileService mockFileService;
   late MockFilePickerService mockFilePickerService;
   late MockBiometricService mockBiometricService;
+  late MockGetPasswordGenerationSettingsUseCase mockGetPasswordSettingsUseCase;
+  late MockSavePasswordGenerationSettingsUseCase
+  mockSavePasswordSettingsUseCase;
 
   final testEntries = [
     PasswordEntry(
@@ -61,6 +72,7 @@ void main() {
     registerFallbackValue(<PasswordEntry>[]);
     registerFallbackValue(<DuplicatePasswordEntry>[]);
     registerFallbackValue(Uint8List(0));
+    registerFallbackValue(PasswordGenerationSettings.initial());
   });
 
   setUp(() {
@@ -72,6 +84,9 @@ void main() {
     mockFileService = MockFileService();
     mockFilePickerService = MockFilePickerService();
     mockBiometricService = MockBiometricService();
+    mockGetPasswordSettingsUseCase = MockGetPasswordGenerationSettingsUseCase();
+    mockSavePasswordSettingsUseCase =
+        MockSavePasswordGenerationSettingsUseCase();
 
     // Default auth success
     when(
@@ -79,6 +94,13 @@ void main() {
         localizedReason: any(named: 'localizedReason'),
       ),
     ).thenAnswer((_) async => true);
+
+    when(
+      () => mockGetPasswordSettingsUseCase(),
+    ).thenReturn(Success(PasswordGenerationSettings.initial()));
+    when(
+      () => mockSavePasswordSettingsUseCase(any()),
+    ).thenAnswer((_) async => const Success(null));
 
     bloc = ImportExportBloc(
       mockImportUseCase,
@@ -88,6 +110,8 @@ void main() {
       mockDataService,
       mockFileService,
       mockFilePickerService,
+      mockGetPasswordSettingsUseCase,
+      mockSavePasswordSettingsUseCase,
     );
   });
 
@@ -101,7 +125,12 @@ void main() {
           when(
             () => mockPasswordRepository.getPasswords(),
           ).thenAnswer((_) async => Success(testEntries));
-          when(() => mockDataService.generateJson(any())).thenReturn('{}');
+          when(
+            () => mockDataService.generateJson(
+              any(),
+              strategies: any(named: 'strategies'),
+            ),
+          ).thenReturn('{}');
           when(
             () => mockFilePickerService.pickSavePath(
               fileName: any(named: 'fileName'),
@@ -142,7 +171,12 @@ void main() {
           when(
             () => mockPasswordRepository.getPasswords(),
           ).thenAnswer((_) async => Success(testEntries));
-          when(() => mockDataService.generateJson(any())).thenReturn('{}');
+          when(
+            () => mockDataService.generateJson(
+              any(),
+              strategies: any(named: 'strategies'),
+            ),
+          ).thenReturn('{}');
           when(
             () => mockFilePickerService.pickSavePath(
               fileName: any(named: 'fileName'),
@@ -170,9 +204,10 @@ void main() {
             when(
               () => mockFileService.readAsString(any()),
             ).thenAnswer((_) async => '{}');
-            when(
-              () => mockDataService.importFromJson(any()),
-            ).thenReturn(testEntries);
+            when(() => mockDataService.importFromJson(any())).thenReturn((
+              passwords: testEntries,
+              strategies: <PasswordGenerationStrategy>[],
+            ));
             when(() => mockImportUseCase(any())).thenAnswer(
               (_) async => const Success(
                 ImportResult(
@@ -216,7 +251,11 @@ void main() {
               () => mockPasswordRepository.getPasswords(),
             ).thenAnswer((_) async => Success(testEntries));
             when(
-              () => mockDataService.generateEncryptedJson(any(), any()),
+              () => mockDataService.generateEncryptedJson(
+                any(),
+                any(),
+                strategies: any(named: 'strategies'),
+              ),
             ).thenReturn(Uint8List(0));
             when(
               () => mockFilePickerService.pickSavePath(
@@ -245,7 +284,10 @@ void main() {
             ).thenAnswer((_) async => Uint8List(0));
             when(
               () => mockDataService.importFromEncrypted(any(), any()),
-            ).thenReturn([testEntries.first]);
+            ).thenReturn((
+              passwords: [testEntries.first],
+              strategies: <PasswordGenerationStrategy>[],
+            ));
             when(() => mockImportUseCase(any())).thenAnswer(
               (_) async => const Success(
                 ImportResult(

--- a/test/features/settings/presentation/screens/settings_screen_test.dart
+++ b/test/features/settings/presentation/screens/settings_screen_test.dart
@@ -134,7 +134,9 @@ void main() {
       },
     );
 
-    testWidgets('Shows success message on ImportSuccess', (tester) async {
+    testWidgets('Shows success message on ImportSuccess and reloads settings', (
+      tester,
+    ) async {
       whenListen(
         mockImportExportBloc,
         Stream.value(const ImportSuccess(5)),
@@ -143,6 +145,23 @@ void main() {
       await loadSettingsScreen(tester);
 
       robot.expectSnackBarContaining(l10n.importSuccess);
+      verify(() => mockSettingsBloc.add(const LoadSettings())).called(1);
+      verify(
+        () => mockImportExportBloc.add(const ResetMigrationStatus()),
+      ).called(1);
+    });
+
+    testWidgets('Reloads settings on DuplicatesResolved', (tester) async {
+      whenListen(
+        mockImportExportBloc,
+        Stream.value(
+          const DuplicatesResolved(totalResolved: 3, totalImported: 3),
+        ),
+        initialState: const ImportExportInitial(),
+      );
+      await loadSettingsScreen(tester);
+
+      verify(() => mockSettingsBloc.add(const LoadSettings())).called(1);
       verify(
         () => mockImportExportBloc.add(const ResetMigrationStatus()),
       ).called(1);


### PR DESCRIPTION
## Description
This PR implements support for exporting and importing user-created password generation strategies under a unified vault backup format. Custom strategies are now packaged alongside credentials in JSON and encrypted `.pvault` formats, and correctly resolved/restored during vault restoration. 

Key changes:
- Refactored `DataService` to format JSON and encrypted backups into a unified map format: `{ "passwords": [...], "strategies": [...] }`.
- Integrated backward compatibility to auto-detect and parse legacy password-only files.
- Refactored `ImportExportBloc` and `ImportExportPathResolver` to handle backup generation and restore for custom strategies, incorporating a conflict resolution strategy (skips default strategies, overwrites matching IDs, and resolves name collisions).
- Added a dynamic warning banner in the `ExportVaultScreen` when the CSV format option is selected since strategies cannot be represented in tabular CSV format.
- Dispatched `LoadSettings()` to `SettingsBloc` upon successful import or duplicate resolution to update the in-memory strategy configuration.

## Related Issues
Closes #47

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🎨 UI/UX refinement

## Checklist
- [x] I have followed the project's [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.

## Screenshots (if applicable)
N/A

## Testing Instructions
1. Navigate to Settings -> Password Generation Strategies, and create a custom strategy.
2. Go to Settings -> Export Vault, enter a password, and export as Encrypted (.pvault).
3. Confirm that when selecting CSV format, a warning banner is shown dynamically stating that CSV does not include strategies.
4. Clear the database (or delete the custom strategy).
5. Go to Settings -> Import Data, select the exported .pvault, enter the password, and resolve conflicts.
6. Verify that the custom strategy is successfully imported and displayed in the Strategy Screen.

<!-- COVERAGE_START -->
## 📊 Code Coverage Report
| Metric | Value |
| :--- | :--- |
| **Total Lines** | 5287 |
| **Lines Hit** | 4285 |
| **Overall Coverage** | **81.05%** |

_Generated by PassVault CI_
<!-- COVERAGE_END -->
